### PR TITLE
Prepare the removal of the name parameter of isInstanceOf.

### DIFF
--- a/lib/src/core_matchers.dart
+++ b/lib/src/core_matchers.dart
@@ -383,12 +383,11 @@ class _IsAnything extends Matcher {
 /// fail. This is because dart2js currently ignores template type
 /// parameters.
 class isInstanceOf<T> extends Matcher {
-  final String _name;
-  const isInstanceOf([name = 'specified type']) : this._name = name;
+  const isInstanceOf([name]);
   bool matches(obj, Map matchState) => obj is T;
   // The description here is lame :-(
   Description describe(Description description) =>
-      description.add('an instance of ${_name}');
+      description.add('an instance of ${T}');
 }
 
 /// A matcher that matches a function call against no exception.


### PR DESCRIPTION
We can just use the generic parameter T directly.

# Why?
We had an issue with the mock package which uses `Matcher.describe` as heuristic to determine whether two Matchers are "equal". This resulted in hard to find bugs when using the default value.

We found that the field is unnecessary and T can be used directly. Which also fixes another hard to find bug when you forget to import the class you are using in isInstanceOf: new isInstanceOf<unknownClass>() === new isInstanceOf<dynamic>().