### PR TITLE
Add invocation_matchers, useful for Mockito/Mocking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,30 @@
-# Don’t commit the following directories created by pub.
-.buildlog
-.pub/
-build/
-packages
-.packages
+# See https://www.dartlang.org/tools/private-files.html
 
-# Or the files created by dart2js.
+# Files and directories created by pub
+.buildlog
+.packages
+.project
+.pub
+**/build
+**/packages
+
+# Files created by dart2js
+# (Most Dart developers will use pub build to compile Dart, use/modify these
+#  rules if you intend to use dart2js directly
+#  Convention is to use extension '.dart.js' for Dart compiled to Javascript to
+#  differentiate from explicit Javascript files)
 *.dart.js
-*.js_
+*.part.js
 *.js.deps
 *.js.map
+*.info.json
 
-# Include when developing application packages.
+# Directory created by dartdoc
+doc/api/
+
+# Don't commit pubspec lock file
+# (Library packages only! Remove pattern if developing an application package)
 pubspec.lock
+
+*.iml
+.idea

--- a/lib/matcher.dart
+++ b/lib/matcher.dart
@@ -7,6 +7,7 @@ export 'src/core_matchers.dart';
 export 'src/description.dart';
 export 'src/error_matchers.dart';
 export 'src/interfaces.dart';
+export 'src/invocation_matchers.dart';
 export 'src/iterable_matchers.dart';
 export 'src/map_matchers.dart';
 export 'src/numeric_matchers.dart';

--- a/lib/src/invocation_matchers.dart
+++ b/lib/src/invocation_matchers.dart
@@ -1,0 +1,168 @@
+// Copyright (c) 2012, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:collection/collection.dart';
+import 'package:meta/meta.dart';
+
+import 'interfaces.dart';
+
+/// Returns a matcher that expects an invocation that matches arguments given.
+///
+/// Both [positionalArguments] and [namedArguments] can also be [Matcher]s:
+///     // Expects an invocation of "foo(String a, bool b)" where "a" must be
+///     // the value 'hello' but "b" may be any value. This would match both
+///     // foo('hello', true), foo('hello', false), and foo('hello', null).
+///     expect(fooInvocation, invokes(
+///       #foo,
+///       positionalArguments: ['hello', any]
+///     ));
+///
+/// Suitable for use in mocking libraries, where `noSuchMethod` can be used to
+/// get a handle to attempted [Invocation] objects and then compared against
+/// what a user expects to be called.
+Matcher invokes(
+  Symbol memberName, {
+  List positionalArguments: const [],
+  Map<Symbol, dynamic> namedArguments: const {},
+  bool isGetter: false,
+  bool isSetter: false,
+}) {
+  if (isGetter && isSetter) {
+    throw new ArgumentError('Cannot set isGetter and iSetter');
+  }
+  if (positionalArguments == null) {
+    throw new ArgumentError.notNull('positionalArguments');
+  }
+  if (namedArguments == null) {
+    throw new ArgumentError.notNull('namedArguments');
+  }
+  return new _InvocationMatcher(new _InvocationSignature(
+    memberName: memberName,
+    positionalArguments: positionalArguments,
+    namedArguments: namedArguments,
+    isGetter: isGetter,
+    isSetter: isSetter,
+  ));
+}
+
+/// Returns a matcher that matches the name and arguments of an [invocation].
+///
+/// To expect the same _signature_ see [invokes].
+Matcher isInvocation(Invocation invocation) =>
+    new _InvocationMatcher(invocation);
+
+class _InvocationSignature extends Invocation {
+  @override
+  final Symbol memberName;
+
+  @override
+  final List positionalArguments;
+
+  @override
+  final Map<Symbol, dynamic> namedArguments;
+
+  @override
+  final bool isGetter;
+
+  @override
+  final bool isSetter;
+
+  _InvocationSignature({
+    @required this.memberName,
+    this.positionalArguments: const [],
+    this.namedArguments: const {},
+    this.isGetter: false,
+    this.isSetter: false,
+  });
+
+  @override
+  bool get isMethod => !isAccessor;
+}
+
+class _InvocationMatcher implements Matcher {
+  static Description _describeInvocation(Description d, Invocation invocation) {
+    if (invocation.isAccessor) {
+      d = d
+          .add(invocation.isGetter ? 'get ' : 'set ')
+          .add(_symbolToString(invocation.memberName));
+      if (invocation.isSetter) {
+        d = d.add(' ').addDescriptionOf(invocation.positionalArguments.first);
+      }
+      return d;
+    }
+    d = d
+        .add(_symbolToString(invocation.memberName))
+        .add('(')
+        .addAll('', ', ', '', invocation.positionalArguments);
+    if (invocation.positionalArguments.isNotEmpty &&
+        invocation.namedArguments.isNotEmpty) {
+      d = d.add(', ');
+    }
+    return d.addAll('', ', ', '', _namedArgsAndValues(invocation)).add(')');
+  }
+
+  static Iterable<String> _namedArgsAndValues(Invocation invocation) =>
+      invocation.namedArguments.keys.map/*<String>*/((name) =>
+          '${_symbolToString(name)}: ${invocation.namedArguments[name]}');
+
+  // This will give is a mangled symbol in dart2js/aot with minification
+  // enabled, but it's safe to assume very few people will use the invocation
+  // matcher in a production test anyway due to noSuchMethod.
+  static String _symbolToString(Symbol symbol) {
+    return symbol.toString().split('"')[1];
+  }
+
+  final Invocation _invocation;
+
+  _InvocationMatcher(this._invocation) {
+    if (_invocation == null) {
+      throw new ArgumentError.notNull();
+    }
+  }
+
+  @override
+  Description describe(Description d) => _describeInvocation(d, _invocation);
+
+  // TODO(matanl): Better implement describeMismatch and use state from matches.
+  // Specifically, if a Matcher is passed as an argument, we'd like to get an
+  // error like "Expected fly(miles: > 10), Actual: fly(miles: 5)".
+  @override
+  Description describeMismatch(item, Description d, _, __) {
+    if (item is Invocation) {
+      d = d.add('Does not match ');
+      return _describeInvocation(d, item);
+    }
+    return d.add('Is not an Invocation');
+  }
+
+  @override
+  bool matches(item, _) =>
+      item is Invocation &&
+      _invocation.memberName == item.memberName &&
+      _invocation.isSetter == item.isSetter &&
+      _invocation.isGetter == item.isGetter &&
+      const ListEquality(const _MatcherEquality())
+          .equals(_invocation.positionalArguments, item.positionalArguments) &&
+      const MapEquality(values: const _MatcherEquality())
+          .equals(_invocation.namedArguments, item.namedArguments);
+}
+
+class _MatcherEquality extends DefaultEquality /* <Matcher | E> */ {
+  const _MatcherEquality();
+
+  @override
+  bool equals(e1, e2) {
+    if (e1 is Matcher && e2 is! Matcher) {
+      return e1.matches(e2, const {});
+    }
+    if (e2 is Matcher && e1 is! Matcher) {
+      return e2.matches(e1, const {});
+    }
+    return super.equals(e1, e2);
+  }
+
+  // We force collisions on every value so equals() is called.
+  @override
+  int hash(_) => 0;
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,5 +8,7 @@ description: Support for specifying test expectations
 homepage: https://github.com/dart-lang/matcher
 environment:
   sdk: '>=1.0.0 <2.0.0'
+dependencies:
+  collection:
 dev_dependencies:
   test: '>=0.12.0 <0.13.0'

--- a/test/invocation_matchers_test.dart
+++ b/test/invocation_matchers_test.dart
@@ -1,0 +1,139 @@
+// Copyright (c) 2012, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:matcher/src/invocation_matchers.dart';
+import 'package:test/test.dart';
+
+import 'test_utils.dart';
+
+Invocation lastInvocation;
+
+void main() {
+  const stub = const Stub();
+
+  group('$isInvocation', () {
+    test('positional arguments', () {
+      var call1 = stub.say('Hello');
+      var call2 = stub.say('Hello');
+      var call3 = stub.say('Guten Tag');
+      shouldPass(call1, isInvocation(call2));
+      shouldFail(
+        call1,
+        isInvocation(call3),
+        "Expected: say('Guten Tag') "
+            "Actual: <Instance of '${call3.runtimeType}'> "
+            "Which: Does not match say('Hello')",
+      );
+    });
+
+    test('named arguments', () {
+      var call1 = stub.eat('Chicken', alsoDrink: true);
+      var call2 = stub.eat('Chicken', alsoDrink: true);
+      var call3 = stub.eat('Chicken', alsoDrink: false);
+      shouldPass(call1, isInvocation(call2));
+      shouldFail(
+        call1,
+        isInvocation(call3),
+        "Expected: eat('Chicken', 'alsoDrink: false') "
+            "Actual: <Instance of '${call3.runtimeType}'> "
+            "Which: Does not match eat('Chicken', 'alsoDrink: true')",
+      );
+    });
+
+    test('optional arguments', () {
+      var call1 = stub.lie(true);
+      var call2 = stub.lie(true);
+      var call3 = stub.lie(false);
+      shouldPass(call1, isInvocation(call2));
+      shouldFail(
+        call1,
+        isInvocation(call3),
+        "Expected: lie(<false>) "
+            "Actual: <Instance of '${call3.runtimeType}'> "
+            "Which: Does not match lie(<true>)",
+      );
+    });
+
+    test('getter', () {
+      var call1 = stub.value;
+      var call2 = stub.value;
+      stub.value = true;
+      var call3 = Stub.lastInvocation;
+      shouldPass(call1, isInvocation(call2));
+      shouldFail(
+        call1,
+        isInvocation(call3),
+        "Expected: set value= <true> "
+            "Actual: <Instance of '${call3.runtimeType}'> "
+            "Which: Does not match get value",
+      );
+    });
+
+    test('setter', () {
+      stub.value = true;
+      var call1 = Stub.lastInvocation;
+      stub.value = true;
+      var call2 = Stub.lastInvocation;
+      stub.value = false;
+      var call3 = Stub.lastInvocation;
+      shouldPass(call1, isInvocation(call2));
+      shouldFail(
+        call1,
+        isInvocation(call3),
+        "Expected: set value= <false> "
+            "Actual: <Instance of '${call3.runtimeType}'> "
+            "Which: Does not match set value= <true>",
+      );
+    });
+  });
+
+  group('$invokes', () {
+    test('positional arguments', () {
+      var call = stub.say('Hello');
+      shouldPass(call, invokes(#say, positionalArguments: ['Hello']));
+      shouldPass(call, invokes(#say, positionalArguments: [anything]));
+      shouldFail(
+        call,
+        invokes(#say, positionalArguments: [isNull]),
+        "Expected: say(null) "
+            "Actual: <Instance of '${call.runtimeType}'> "
+            "Which: Does not match say('Hello')",
+      );
+    });
+
+    test('named arguments', () {
+      var call = stub.fly(miles: 10);
+      shouldPass(call, invokes(#fly, namedArguments: {#miles: 10}));
+      shouldPass(call, invokes(#fly, namedArguments: {#miles: greaterThan(5)}));
+      shouldFail(
+        call,
+        invokes(#fly, namedArguments: {#miles: 11}),
+        "Expected: fly('miles: 11') "
+            "Actual: <Instance of '${call.runtimeType}'> "
+            "Which: Does not match fly('miles: 10')",
+      );
+    });
+  });
+}
+
+abstract class Interface {
+  bool get value;
+  set value(value);
+  say(String text);
+  eat(String food, {bool alsoDrink});
+  lie([bool facingDown]);
+  fly({int miles});
+}
+
+/// An example of a class that captures Invocation objects.
+///
+/// Any call always returns an [Invocation].
+class Stub implements Interface {
+  static Invocation lastInvocation;
+
+  const Stub();
+
+  @override
+  noSuchMethod(Invocation invocation) => lastInvocation = invocation;
+}


### PR DESCRIPTION
[Mockito](https://github.com/fibulwinter/dart-mockito) has sort of a half-rolled `InvocationMatcher` (that does not implement the `Matcher` interface). This is my attempt to clean up the use case and add it to this package for use in mockito and other libraries that will want to match `Invocation` instances.

Potential future use in Mockito:

```dart
// This will be stored as a Matcher...
when(stub.doThing()).thenReturn(false);

// And compared when stub.doThing() is called later
noSuchMethod(Invocation invocation) {
  for (var expectation in expectations) {
    if (expectation.matches(invocation)) {
      return expectation.answer();
    }
  }
}
```

/cc @srawlins for FYI on Mockito

(I can increment the pubspec after https://github.com/dart-lang/test/pull/468)