### PR TITLE
Change wrapMatcher to avoid relying on fuzzy arrows

### DIFF
--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -5,7 +5,7 @@
 import 'core_matchers.dart';
 import 'interfaces.dart';
 
-typedef bool _Predicate(value);
+typedef bool _Predicate<T>(T value);
 
 /// A [Map] between whitespace characters and their escape sequences.
 const _escapeMap = const {
@@ -38,8 +38,13 @@ void addStateInfo(Map matchState, Map values) {
 Matcher wrapMatcher(x) {
   if (x is Matcher) {
     return x;
-  } else if (x is _Predicate) {
+  } else if (x is _Predicate<Object>) {
+    // x is already a predicate that can handle anything
     return predicate(x);
+  } else if (x is _Predicate<Null>) {
+    // x is a unary predicate, but expects a specific type
+    // so wrap it.
+    return predicate((a) => (x as dynamic)(a));
   } else {
     return equals(x);
   }


### PR DESCRIPTION
The predicate case in wrapMatcher is essentially relying on a now deprecated feature of strong mode that treated `dynamic` as `bottom` when used in a function argument position.  This feature is being deprecated and removed in Dart 2.0 (more context here https://github.com/dart-lang/sdk/issues/29630 ).  

This adds code to explicitly handle the cases previously handled using fuzzy arrows.