### PR TITLE
Strong mode fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.12.1+3
+
+* Make `predicate` and `pairwiseCompare` generic methods to allow typed
+ functions to be passed to them as arguments.
+
+* Make internal implementations take better advantage of type promotion to avoid
+  dynamic call overhead.
+
 ## 0.12.1+2
 
 * Fixed small documentation issues.

--- a/lib/src/core_matchers.dart
+++ b/lib/src/core_matchers.dart
@@ -110,6 +110,8 @@ Matcher equals(expected, [int limit = 100]) => expected is String
     ? new _StringEqualsMatcher(expected)
     : new _DeepMatcher(expected, limit);
 
+typedef _RecursiveMatcher = List<String> Function(dynamic, dynamic, String, int);
+
 class _DeepMatcher extends Matcher {
   final _expected;
   final int _limit;
@@ -117,9 +119,10 @@ class _DeepMatcher extends Matcher {
   _DeepMatcher(this._expected, [int limit = 1000]) : this._limit = limit;
 
   // Returns a pair (reason, location)
-  List _compareIterables(expected, actual, matcher, depth, location) {
-    if (actual is! Iterable) return ['is not Iterable', location];
-
+  List<String> _compareIterables(Iterable expected, Object _actual,
+      _RecursiveMatcher matcher, int depth, String location) {
+    if (_actual is! Iterable) return ['is not Iterable', location];
+    var actual = _actual as Iterable;
     var expectedIterator = expected.iterator;
     var actualIterator = actual.iterator;
     for (var index = 0;; index++) {
@@ -142,9 +145,9 @@ class _DeepMatcher extends Matcher {
     }
   }
 
-  List _compareSets(Set expected, actual, matcher, depth, location) {
-    if (actual is! Iterable) return ['is not Iterable', location];
-    actual = actual.toSet();
+  List<String> _compareSets(Set expected, Object _actual, _RecursiveMatcher matcher, int depth, String location) {
+    if (_actual is! Iterable) return ['is not Iterable', location];
+    Set actual = (_actual as Iterable).toSet();
 
     for (var expectedElement in expected) {
       if (actual.every((actualElement) =>
@@ -162,7 +165,7 @@ class _DeepMatcher extends Matcher {
     }
   }
 
-  List _recursiveMatch(expected, actual, String location, int depth) {
+  List<String> _recursiveMatch(Object expected, Object actual, String location, int depth) {
     // If the expected value is a matcher, try to match it.
     if (expected is Matcher) {
       var matchState = {};
@@ -193,17 +196,17 @@ class _DeepMatcher extends Matcher {
             expected, actual, _recursiveMatch, depth + 1, location);
       } else if (expected is Map) {
         if (actual is! Map) return ['expected a map', location];
-
-        var err = (expected.length == actual.length)
+        var map = (actual as Map);
+        var err = (expected.length == map.length)
             ? ''
             : 'has different length and ';
         for (var key in expected.keys) {
-          if (!actual.containsKey(key)) {
+          if (!map.containsKey(key)) {
             return ["${err}is missing map key '$key'", location];
           }
         }
 
-        for (var key in actual.keys) {
+        for (var key in map.keys) {
           if (!expected.containsKey(key)) {
             return ["${err}has extra map key '$key'", location];
           }
@@ -211,7 +214,7 @@ class _DeepMatcher extends Matcher {
 
         for (var key in expected.keys) {
           var rp = _recursiveMatch(
-              expected[key], actual[key], "$location['$key']", depth + 1);
+              expected[key], map[key], "$location['$key']", depth + 1);
           if (rp != null) return rp;
         }
 
@@ -239,7 +242,7 @@ class _DeepMatcher extends Matcher {
   String _match(expected, actual, Map matchState) {
     var rp = _recursiveMatch(expected, actual, '', 0);
     if (rp == null) return null;
-    var reason;
+    String reason;
     if (rp[0].length > 0) {
       if (rp[1].length > 0) {
         reason = "${rp[0]} at location ${rp[1]}";
@@ -567,18 +570,19 @@ class _In extends Matcher {
 /// For example:
 ///
 ///     expect(v, predicate((x) => ((x % 2) == 0), "is even"))
-Matcher predicate(bool f(value), [String description = 'satisfies function']) =>
+Matcher predicate<T>(bool f(T value),
+        [String description = 'satisfies function']) =>
     new _Predicate(f, description);
 
-typedef bool _PredicateFunction(value);
+typedef bool _PredicateFunction<T>(T value);
 
-class _Predicate extends Matcher {
-  final _PredicateFunction _matcher;
+class _Predicate<T> extends Matcher {
+  final _PredicateFunction<T> _matcher;
   final String _description;
 
-  const _Predicate(this._matcher, this._description);
+  _Predicate(this._matcher, this._description);
 
-  bool matches(item, Map matchState) => _matcher(item);
+  bool matches(item, Map matchState) => _matcher(item as T);
 
   Description describe(Description description) =>
       description.add(_description);

--- a/lib/src/core_matchers.dart
+++ b/lib/src/core_matchers.dart
@@ -120,50 +120,56 @@ class _DeepMatcher extends Matcher {
   _DeepMatcher(this._expected, [int limit = 1000]) : this._limit = limit;
 
   // Returns a pair (reason, location)
-  List<String> _compareIterables(Iterable expected, Object _actual,
+  List<String> _compareIterables(Iterable expected, Object actual,
       _RecursiveMatcher matcher, int depth, String location) {
-    if (_actual is! Iterable) return ['is not Iterable', location];
-    var actual = _actual as Iterable;
-    var expectedIterator = expected.iterator;
-    var actualIterator = actual.iterator;
-    for (var index = 0;; index++) {
-      // Advance in lockstep.
-      var expectedNext = expectedIterator.moveNext();
-      var actualNext = actualIterator.moveNext();
+    if (actual is Iterable) {
+      var expectedIterator = expected.iterator;
+      var actualIterator = actual.iterator;
+      for (var index = 0;; index++) {
+        // Advance in lockstep.
+        var expectedNext = expectedIterator.moveNext();
+        var actualNext = actualIterator.moveNext();
 
-      // If we reached the end of both, we succeeded.
-      if (!expectedNext && !actualNext) return null;
+        // If we reached the end of both, we succeeded.
+        if (!expectedNext && !actualNext) return null;
 
-      // Fail if their lengths are different.
-      var newLocation = '$location[$index]';
-      if (!expectedNext) return ['longer than expected', newLocation];
-      if (!actualNext) return ['shorter than expected', newLocation];
+        // Fail if their lengths are different.
+        var newLocation = '$location[$index]';
+        if (!expectedNext) return ['longer than expected', newLocation];
+        if (!actualNext) return ['shorter than expected', newLocation];
 
-      // Match the elements.
-      var rp = matcher(
-          expectedIterator.current, actualIterator.current, newLocation, depth);
-      if (rp != null) return rp;
+        // Match the elements.
+        var rp = matcher(
+            expectedIterator.current, actualIterator.current, newLocation,
+            depth);
+        if (rp != null) return rp;
+      }
+    } else {
+      return ['is not Iterable', location];
     }
   }
 
-  List<String> _compareSets(Set expected, Object _actual,
+  List<String> _compareSets(Set expected, Object actual,
       _RecursiveMatcher matcher, int depth, String location) {
-    if (_actual is! Iterable) return ['is not Iterable', location];
-    Set actual = (_actual as Iterable).toSet();
+    if (actual is Iterable) {
+      Set other = actual.toSet();
 
-    for (var expectedElement in expected) {
-      if (actual.every((actualElement) =>
-          matcher(expectedElement, actualElement, location, depth) != null)) {
-        return ['does not contain $expectedElement', location];
+      for (var expectedElement in expected) {
+        if (other.every((actualElement) =>
+        matcher(expectedElement, actualElement, location, depth) != null)) {
+          return ['does not contain $expectedElement', location];
+        }
       }
-    }
 
-    if (actual.length > expected.length) {
-      return ['larger than expected', location];
-    } else if (actual.length < expected.length) {
-      return ['smaller than expected', location];
+      if (other.length > expected.length) {
+        return ['larger than expected', location];
+      } else if (other.length < expected.length) {
+        return ['smaller than expected', location];
+      } else {
+        return null;
+      }
     } else {
-      return null;
+      return ['is not Iterable', location];
     }
   }
 

--- a/lib/src/core_matchers.dart
+++ b/lib/src/core_matchers.dart
@@ -139,9 +139,8 @@ class _DeepMatcher extends Matcher {
         if (!actualNext) return ['shorter than expected', newLocation];
 
         // Match the elements.
-        var rp = matcher(
-            expectedIterator.current, actualIterator.current, newLocation,
-            depth);
+        var rp = matcher(expectedIterator.current, actualIterator.current,
+            newLocation, depth);
         if (rp != null) return rp;
       }
     } else {
@@ -156,7 +155,7 @@ class _DeepMatcher extends Matcher {
 
       for (var expectedElement in expected) {
         if (other.every((actualElement) =>
-        matcher(expectedElement, actualElement, location, depth) != null)) {
+            matcher(expectedElement, actualElement, location, depth) != null)) {
           return ['does not contain $expectedElement', location];
         }
       }

--- a/lib/src/core_matchers.dart
+++ b/lib/src/core_matchers.dart
@@ -110,7 +110,8 @@ Matcher equals(expected, [int limit = 100]) => expected is String
     ? new _StringEqualsMatcher(expected)
     : new _DeepMatcher(expected, limit);
 
-typedef _RecursiveMatcher = List<String> Function(dynamic, dynamic, String, int);
+typedef _RecursiveMatcher = List<String> Function(
+    dynamic, dynamic, String, int);
 
 class _DeepMatcher extends Matcher {
   final _expected;
@@ -145,7 +146,8 @@ class _DeepMatcher extends Matcher {
     }
   }
 
-  List<String> _compareSets(Set expected, Object _actual, _RecursiveMatcher matcher, int depth, String location) {
+  List<String> _compareSets(Set expected, Object _actual,
+      _RecursiveMatcher matcher, int depth, String location) {
     if (_actual is! Iterable) return ['is not Iterable', location];
     Set actual = (_actual as Iterable).toSet();
 
@@ -165,7 +167,8 @@ class _DeepMatcher extends Matcher {
     }
   }
 
-  List<String> _recursiveMatch(Object expected, Object actual, String location, int depth) {
+  List<String> _recursiveMatch(
+      Object expected, Object actual, String location, int depth) {
     // If the expected value is a matcher, try to match it.
     if (expected is Matcher) {
       var matchState = {};
@@ -197,9 +200,8 @@ class _DeepMatcher extends Matcher {
       } else if (expected is Map) {
         if (actual is! Map) return ['expected a map', location];
         var map = (actual as Map);
-        var err = (expected.length == map.length)
-            ? ''
-            : 'has different length and ';
+        var err =
+            (expected.length == map.length) ? '' : 'has different length and ';
         for (var key in expected.keys) {
           if (!map.containsKey(key)) {
             return ["${err}is missing map key '$key'", location];

--- a/lib/src/iterable_matchers.dart
+++ b/lib/src/iterable_matchers.dart
@@ -154,9 +154,9 @@ class _UnorderedMatches extends Matcher {
   _UnorderedMatches(Iterable expected)
       : _expected = expected.map(wrapMatcher).toList();
 
-  String _test(item) {
-    if (item is! Iterable) return 'not iterable';
-    item = item.toList();
+  String _test(_item) {
+    if (_item is! Iterable) return 'not iterable';
+    var item = (_item as Iterable).toList();
 
     // Check the lengths are the same.
     if (_expected.length > item.length) {
@@ -210,21 +210,22 @@ class _UnorderedMatches extends Matcher {
 /// The [comparator] function, taking an expected and an actual argument, and
 /// returning whether they match, will be applied to each pair in order.
 /// [description] should be a meaningful name for the comparator.
-Matcher pairwiseCompare(
-        Iterable expected, bool comparator(a, b), String description) =>
+Matcher pairwiseCompare<S, T>(
+        Iterable<S> expected, bool comparator(S a, T b), String description) =>
     new _PairwiseCompare(expected, comparator, description);
 
-typedef bool _Comparator(a, b);
+typedef bool _Comparator<S, T>(S a, T b);
 
-class _PairwiseCompare extends _IterableMatcher {
-  final Iterable _expected;
-  final _Comparator _comparator;
+class _PairwiseCompare<S, T> extends _IterableMatcher {
+  final Iterable<S> _expected;
+  final _Comparator<S, T> _comparator;
   final String _description;
 
   _PairwiseCompare(this._expected, this._comparator, this._description);
 
-  bool matches(item, Map matchState) {
-    if (item is! Iterable) return false;
+  bool matches(_item, Map matchState) {
+    if (_item is! Iterable) return false;
+    var item = _item as Iterable;
     if (item.length != _expected.length) return false;
     var iterator = item.iterator;
     var i = 0;

--- a/lib/src/numeric_matchers.dart
+++ b/lib/src/numeric_matchers.dart
@@ -17,11 +17,13 @@ class _IsCloseTo extends Matcher {
   const _IsCloseTo(this._value, this._delta);
 
   bool matches(item, Map matchState) {
-    if (item is! num) return false;
-
-    var diff = item - _value;
-    if (diff < 0) diff = -diff;
-    return (diff <= _delta);
+    if (item is num) {
+      var diff = item - _value;
+      if (diff < 0) diff = -diff;
+      return (diff <= _delta);
+    } else {
+      return false;
+    }
   }
 
   Description describe(Description description) => description
@@ -32,12 +34,12 @@ class _IsCloseTo extends Matcher {
 
   Description describeMismatch(
       item, Description mismatchDescription, Map matchState, bool verbose) {
-    if (item is! num) {
-      return mismatchDescription.add(' not numeric');
-    } else {
+    if (item is num) {
       var diff = item - _value;
       if (diff < 0) diff = -diff;
       return mismatchDescription.add(' differs by ').addDescriptionOf(diff);
+    } else {
+      return mismatchDescription.add(' not numeric');
     }
   }
 }
@@ -69,10 +71,11 @@ class _InRange extends Matcher {
   const _InRange(
       this._low, this._high, this._lowMatchValue, this._highMatchValue);
 
-  bool matches(value, Map matchState) {
-    if (value is! num) {
+  bool matches(_value, Map matchState) {
+    if (_value is! num) {
       return false;
     }
+    var value = _value as num;
     if (value < _low || value > _high) {
       return false;
     }

--- a/lib/src/numeric_matchers.dart
+++ b/lib/src/numeric_matchers.dart
@@ -71,21 +71,21 @@ class _InRange extends Matcher {
   const _InRange(
       this._low, this._high, this._lowMatchValue, this._highMatchValue);
 
-  bool matches(_value, Map matchState) {
-    if (_value is! num) {
+  bool matches(value, Map matchState) {
+    if (value is num) {
+      if (value < _low || value > _high) {
+        return false;
+      }
+      if (value == _low) {
+        return _lowMatchValue;
+      }
+      if (value == _high) {
+        return _highMatchValue;
+      }
+      return true;
+    } else {
       return false;
     }
-    var value = _value as num;
-    if (value < _low || value > _high) {
-      return false;
-    }
-    if (value == _low) {
-      return _lowMatchValue;
-    }
-    if (value == _high) {
-      return _highMatchValue;
-    }
-    return true;
   }
 
   Description describe(Description description) =>

--- a/lib/src/string_matchers.dart
+++ b/lib/src/string_matchers.dart
@@ -117,10 +117,11 @@ class _StringContainsInOrder extends _StringMatcher {
 
   const _StringContainsInOrder(this._substrings);
 
-  bool matches(item, Map matchState) {
-    if (!(item is String)) {
+  bool matches(_item, Map matchState) {
+    if (!(_item is String)) {
       return false;
     }
+    var item = _item as String;
     var from_index = 0;
     for (var s in _substrings) {
       from_index = item.indexOf(s, from_index);

--- a/lib/src/string_matchers.dart
+++ b/lib/src/string_matchers.dart
@@ -117,17 +117,17 @@ class _StringContainsInOrder extends _StringMatcher {
 
   const _StringContainsInOrder(this._substrings);
 
-  bool matches(_item, Map matchState) {
-    if (!(_item is String)) {
+  bool matches(item, Map matchState) {
+    if (item is String) {
+      var from_index = 0;
+      for (var s in _substrings) {
+        from_index = item.indexOf(s, from_index);
+        if (from_index < 0) return false;
+      }
+      return true;
+    } else {
       return false;
     }
-    var item = _item as String;
-    var from_index = 0;
-    for (var s in _substrings) {
-      from_index = item.indexOf(s, from_index);
-      if (from_index < 0) return false;
-    }
-    return true;
   }
 
   Description describe(Description description) => description.addAll(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: matcher
-version: 0.12.1+2
+version: 0.12.1+3
 author: Dart Team <misc@dartlang.org>
 description: Support for specifying test expectations
 homepage: https://github.com/dart-lang/matcher
 environment:
-  sdk: '>=1.8.0 <2.0.0-dev.infinity'
+  sdk: '>=1.23.0 <2.0.0-dev.infinity'
 dependencies:
   stack_trace: '^1.2.0'
 dev_dependencies:


### PR DESCRIPTION
Sorry for the second PR in a row.   This is part of the continuing effort to eliminate fuzzy arrows:  https://github.com/dart-lang/sdk/issues/29630 .

This PR isn't required for the effort, but it is intended to make the API friendlier to typed code, so that fewer changes are required in user code.  I noticed when working on other code that calls to `predicate` cause frequent error messages about fuzzy arrows.  The only two API facing changes are to `predicate` and `pairWiseCompare`.  In both cases, I am proposing to make those functions generic, so that their function argument can be typed precisely.  This is so that code that looks like:

```dart
predicate((List<int> x) => x[0] = 1);
```

will be strong mode clean, instead of having to be written as:

```dart
predicate((_x) {List<int> x = _x; return x[0] == 1;});
```

or made fully dynamic.

I'm not sure whether this is considered a breaking change in the API or not - I believe that all existing non-strong mode code should be unaffected.  Strong mode code that uses `--no-implicit-dynamic` could potentially get new errors.

In passing, I noticed a fair bit of internal code which is more dynamic than it needed to be (and hence which will be slow on DDC).  I made a number of passing changes to enable promotion to kick in so that the code is more statically typed.  All of these changes are intended to be semantics preserving.

