### PR TITLE
Remove -dev.infinity from SDK constraint

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: matcher
-version: 0.12.1+3
+version: 0.12.1+4
 author: Dart Team <misc@dartlang.org>
 description: Support for specifying test expectations
 homepage: https://github.com/dart-lang/matcher
 environment:
-  sdk: '>=1.23.0 <2.0.0-dev.infinity'
+  sdk: '>=1.23.0 <2.0.0'
 dependencies:
   stack_trace: '^1.2.0'
 dev_dependencies:


### PR DESCRIPTION
No longer needed with current design. Blocks `pub get` from edge builds