### PR TITLE
Fix unorderedMatches for poorly ordered input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.12.2
+
+* Fixed `unorderedMatches` in cases where the matchers may match more than one
+  element and order of the elements doesn't line up with the order of the
+  matchers.
+
 ## 0.12.1+4
 
 * Fixed SDK constraint to allow edge builds.

--- a/lib/src/iterable_matchers.dart
+++ b/lib/src/iterable_matchers.dart
@@ -182,25 +182,23 @@ class _UnorderedMatches extends Matcher {
     for (int valueIndex = 0; valueIndex < values.length; valueIndex++) {
       _findPairing(edges, valueIndex, matched);
     }
-    var unmatched = <Matcher>[];
     for (int matcherIndex = 0;
         matcherIndex < _expected.length;
         matcherIndex++) {
       if (matched[matcherIndex] == null) {
-        unmatched.add(_expected[matcherIndex]);
-      }
-    }
-    if (unmatched.isNotEmpty) {
-      if (unmatched.length > 1) {
-        return new StringDescription()
-            .add('has no match for any of ')
-            .addAll('(', ', ', ')', unmatched)
-            .toString();
-      } else {
-        return new StringDescription()
+        final description = new StringDescription()
             .add('has no match for ')
-            .addDescriptionOf(unmatched.single)
-            .toString();
+            .addDescriptionOf(_expected[matcherIndex])
+            .add(' at index $matcherIndex');
+        final remainingUnmatched = matched
+            .sublist(matcherIndex + 1)
+            .where((m) => m == null)
+            .length;
+        return remainingUnmatched == 0
+            ? description.toString()
+            : description
+                .add(' along with $remainingUnmatched other unmatched')
+                .toString();
       }
     }
     return null;

--- a/lib/src/iterable_matchers.dart
+++ b/lib/src/iterable_matchers.dart
@@ -190,10 +190,8 @@ class _UnorderedMatches extends Matcher {
             .add('has no match for ')
             .addDescriptionOf(_expected[matcherIndex])
             .add(' at index $matcherIndex');
-        final remainingUnmatched = matched
-            .sublist(matcherIndex + 1)
-            .where((m) => m == null)
-            .length;
+        final remainingUnmatched =
+            matched.sublist(matcherIndex + 1).where((m) => m == null).length;
         return remainingUnmatched == 0
             ? description.toString()
             : description
@@ -228,8 +226,7 @@ class _UnorderedMatches extends Matcher {
     for (final matcherIndex in possiblePairings) {
       seen.add(matcherIndex);
       final previouslyMatched = matched[matcherIndex];
-      final canPlaceWithoutConflict = previouslyMatched == null;
-      if (canPlaceWithoutConflict ||
+      if (previouslyMatched == null ||
           // If the matcher isn't already free, check whether the existing value
           // occupying the matcher can be bumped to another one.
           _findPairing(edges, matched[matcherIndex], matched, seen)) {

--- a/lib/src/iterable_matchers.dart
+++ b/lib/src/iterable_matchers.dart
@@ -168,7 +168,8 @@ class _UnorderedMatches extends Matcher {
       return 'has too many elements (${values.length} > ${_expected.length})';
     }
 
-    var edges = values.map((_) => <int>[]).toList(growable: false);
+    var edges =
+        new List.generate(values.length, (_) => <int>[], growable: false);
     for (int v = 0; v < values.length; v++) {
       for (int m = 0; m < _expected.length; m++) {
         if (_expected[m].matches(values[v], {})) {

--- a/lib/src/iterable_matchers.dart
+++ b/lib/src/iterable_matchers.dart
@@ -218,19 +218,20 @@ class _UnorderedMatches extends Matcher {
   /// unmatched matcher and updates the state of [matched].
   ///
   /// If there is a conflic where multiple values may match the same matcher
-  /// recursively looks for a new place to match the old value. [seen] trackes
-  /// the matchers that have been used _during_ this search.
+  /// recursively looks for a new place to match the old value. [reserved]
+  /// tracks the matchers that have been used _during_ this search.
   bool _findPairing(List<List<int>> edges, int valueIndex, List<int> matched,
-      [Set<int> seen]) {
-    seen ??= new Set<int>();
-    final possiblePairings = edges[valueIndex].where((m) => !seen.contains(m));
+      [Set<int> reserved]) {
+    reserved ??= new Set<int>();
+    final possiblePairings =
+        edges[valueIndex].where((m) => !reserved.contains(m));
     for (final matcherIndex in possiblePairings) {
-      seen.add(matcherIndex);
+      reserved.add(matcherIndex);
       final previouslyMatched = matched[matcherIndex];
       if (previouslyMatched == null ||
           // If the matcher isn't already free, check whether the existing value
           // occupying the matcher can be bumped to another one.
-          _findPairing(edges, matched[matcherIndex], matched, seen)) {
+          _findPairing(edges, matched[matcherIndex], matched, reserved)) {
         matched[matcherIndex] = valueIndex;
         return true;
       }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,3 +9,6 @@ dependencies:
   stack_trace: '^1.2.0'
 dev_dependencies:
   test: '>=0.12.0 <0.13.0'
+
+dependency_overrides:
+  test: ^0.12.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: matcher
-version: 0.12.1+4
+version: 0.12.2-dev
 author: Dart Team <misc@dartlang.org>
 description: Support for specifying test expectations
 homepage: https://github.com/dart-lang/matcher

--- a/test/iterable_matchers_test.dart
+++ b/test/iterable_matchers_test.dart
@@ -143,13 +143,22 @@ void main() {
         unorderedEquals([3, 1]),
         "Expected: equals [3, 1] unordered "
         "Actual: [1, 2] "
-        "Which: has no match for <3> at index 0");
+        "Which: has no match for <3>");
+    shouldFail(
+        d,
+        unorderedEquals([3, 4]),
+        "Expected: equals [3, 4] unordered "
+        "Actual: [1, 2] "
+        "Which: has no match for any of (<3>, <4>)");
   });
 
-  test('unorderedMatchess', () {
+  test('unorderedMatches', () {
     var d = [1, 2];
     shouldPass(d, unorderedMatches([2, 1]));
     shouldPass(d, unorderedMatches([greaterThan(1), greaterThan(0)]));
+    shouldPass(d, unorderedMatches([greaterThan(0), greaterThan(1)]));
+    shouldPass([2, 1], unorderedMatches([greaterThan(1), greaterThan(0)]));
+    shouldPass([2, 1], unorderedMatches([greaterThan(0), greaterThan(1)]));
     shouldFail(
         d,
         unorderedMatches([greaterThan(0)]),
@@ -167,14 +176,14 @@ void main() {
         unorderedMatches([3, 1]),
         "Expected: matches [<3>, <1>] unordered "
         "Actual: [1, 2] "
-        "Which: has no match for <3> at index 0");
+        "Which: has no match for <3>");
     shouldFail(
         d,
         unorderedMatches([greaterThan(3), greaterThan(0)]),
         "Expected: matches [a value greater than <3>, a value greater than "
         "<0>] unordered "
         "Actual: [1, 2] "
-        "Which: has no match for a value greater than <3> at index 0");
+        "Which: has no match for a value greater than <3>");
   });
 
   test('containsAllInOrder', () {

--- a/test/iterable_matchers_test.dart
+++ b/test/iterable_matchers_test.dart
@@ -143,13 +143,14 @@ void main() {
         unorderedEquals([3, 1]),
         "Expected: equals [3, 1] unordered "
         "Actual: [1, 2] "
-        "Which: has no match for <3>");
+        "Which: has no match for <3> at index 0");
     shouldFail(
         d,
         unorderedEquals([3, 4]),
         "Expected: equals [3, 4] unordered "
         "Actual: [1, 2] "
-        "Which: has no match for any of (<3>, <4>)");
+        "Which: has no match for <3> at index 0"
+        " along with 1 other unmatched");
   });
 
   test('unorderedMatches', () {
@@ -176,14 +177,14 @@ void main() {
         unorderedMatches([3, 1]),
         "Expected: matches [<3>, <1>] unordered "
         "Actual: [1, 2] "
-        "Which: has no match for <3>");
+        "Which: has no match for <3> at index 0");
     shouldFail(
         d,
         unorderedMatches([greaterThan(3), greaterThan(0)]),
         "Expected: matches [a value greater than <3>, a value greater than "
         "<0>] unordered "
         "Actual: [1, 2] "
-        "Which: has no match for a value greater than <3>");
+        "Which: has no match for a value greater than <3> at index 0");
   });
 
   test('containsAllInOrder', () {

--- a/test/iterable_matchers_test.dart
+++ b/test/iterable_matchers_test.dart
@@ -159,7 +159,19 @@ void main() {
     shouldPass(d, unorderedMatches([greaterThan(1), greaterThan(0)]));
     shouldPass(d, unorderedMatches([greaterThan(0), greaterThan(1)]));
     shouldPass([2, 1], unorderedMatches([greaterThan(1), greaterThan(0)]));
+
     shouldPass([2, 1], unorderedMatches([greaterThan(0), greaterThan(1)]));
+    // Excersize the case where pairings should get "bumped" multiple times
+    shouldPass(
+        [0, 1, 2, 3, 5, 6],
+        unorderedMatches([
+          greaterThan(1), // 6
+          equals(2), // 2
+          allOf([lessThan(3), isNot(0)]), // 1
+          equals(0), // 0
+          predicate((v) => v % 2 == 1), // 3
+          equals(5), // 5
+        ]));
     shouldFail(
         d,
         unorderedMatches([greaterThan(0)]),


### PR DESCRIPTION
Fixes #73

Reimplements the unordered matcher using a recursive search assuming
that matchers can match multiple values in the input rather than a
greedy algorithm which allows a matcher to "consume" a value that is
needed for some other matcher.

User visible differences:
- May match inputs that would have previously been (incorrectly)
  rejected.
- The failure description no longer includes the index of the matcher
  which is unmatched, and all unmatched matchers are printed rather than
  the first.