### PR TITLE
fix: prettyPrint for instance of `Type` is not an instance of the Type

### DIFF
--- a/lib/src/pretty_print.dart
+++ b/lib/src/pretty_print.dart
@@ -107,8 +107,6 @@ String prettyPrint(object, {int maxLineLength, int maxItems}) {
           object == null ||
           defaultToString) {
         return value;
-      } else if (object is Type) {
-        return 'instance of `$object`';
       } else {
         return "${_typeName(object)}:$value";
       }
@@ -127,6 +125,7 @@ String _typeName(x) {
   // So we play safe here.
   try {
     if (x == null) return "null";
+    if (x is Type) return "Type";
     var type = x.runtimeType.toString();
     // TODO(nweiz): if the object's type is private, find a public superclass to
     // display once there's a portable API to do that.

--- a/test/pretty_print_test.dart
+++ b/test/pretty_print_test.dart
@@ -257,7 +257,7 @@ void main() {
   });
 
   test('Type', () {
-    expect(prettyPrint(''.runtimeType), 'instance of `String`');
+    expect(prettyPrint(''.runtimeType), 'Type:<String>');
   });
 }
 


### PR DESCRIPTION
Fixes prettyPrint function and associated test

Follow-up to https://github.com/dart-lang/matcher/commit/d947ffb7070f7acfa4b6e92c5f42dcd568ca245a