### PR TITLE
Fix ignores for deprecated member usage

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -6,6 +6,7 @@ analyzer:
     unused_element: error
     unused_import: error
     unused_local_variable: error
+    todo: ignore
 linter:
   rules:
     - always_declare_return_types

--- a/lib/src/type_matcher.dart
+++ b/lib/src/type_matcher.dart
@@ -48,7 +48,7 @@ class TypeMatcher<T> extends Matcher {
           'This argument will be removed in the next release.')
           String name])
       : _name =
-            // ignore: deprecated_member_use
+            // ignore: deprecated_member_use_from_same_package
             name;
 
   /// Returns a new [TypeMatcher] that validates the existing type as well as

--- a/test/type_matcher_test.dart
+++ b/test/type_matcher_test.dart
@@ -26,7 +26,7 @@ void main() {
   _test('NullThrownError', isNullThrownError, NullThrownError());
 
   group('custom `TypeMatcher`', () {
-    // ignore: deprecated_member_use
+    // ignore: deprecated_member_use_from_same_package
     _test('String', const isInstanceOf<String>(), 'hello');
     _test('String', const _StringMatcher(), 'hello');
     _test('String', const TypeMatcher<String>(), 'hello');
@@ -52,7 +52,7 @@ void _test(String name, Matcher typeMatcher, Object matchingType) {
 // Validate that existing implementations continue to work.
 class _StringMatcher extends TypeMatcher {
   const _StringMatcher() : super(
-            // ignore: deprecated_member_use
+            // ignore: deprecated_member_use_from_same_package
             'String');
 
   bool matches(item, Map matchState) => item is String;


### PR DESCRIPTION
The name of the error reported in the latest SDK changed.

Also ignore todos so it's easy to see when the analysis list is clean.