### PR TITLE
Add `isA<T>()` to create TypeMatcher instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.12.5
+
+- Add `isA()` to create `TypeMatcher` instances in a more fluent way.
+
 ## 0.12.4
 
 - Add isCastError.

--- a/lib/src/core_matchers.dart
+++ b/lib/src/core_matchers.dart
@@ -131,7 +131,7 @@ class _IsAnything extends Matcher {
 ///
 /// Returns a matcher that matches if an object is an instance
 /// of [T] (or a subtype).
-@Deprecated('Use `const TypeMatcher<MyType>()` instead.')
+@Deprecated('Use `isA<MyType>()` instead.')
 // ignore: camel_case_types
 class isInstanceOf<T> extends TypeMatcher<T> {
   const isInstanceOf();

--- a/lib/src/type_matcher.dart
+++ b/lib/src/type_matcher.dart
@@ -5,6 +5,17 @@
 import 'having_matcher.dart';
 import 'interfaces.dart';
 
+
+/// Returns a matcher that matches objects with type [T].
+///
+/// ```dart
+/// expect(shouldBeDuration, isA<Duration>());
+/// ```
+///
+/// Expectations can be chained on top of the type using the
+/// [TypeMatcher.having] method to add additional constraints.
+TypeMatcher<T> isA<T>() => TypeMatcher<T>();
+
 /// A [Matcher] subclass that supports validating the [Type] of the target
 /// object.
 ///
@@ -43,6 +54,10 @@ import 'interfaces.dart';
 /// ```
 class TypeMatcher<T> extends Matcher {
   final String _name;
+
+  /// Create a matcher matches instances of type [T].
+  ///
+  /// For a fluent API to create TypeMatchers see [isA].
   const TypeMatcher(
       [@Deprecated('Provide a type argument to TypeMatcher and omit the name. '
           'This argument will be removed in the next release.')

--- a/lib/src/type_matcher.dart
+++ b/lib/src/type_matcher.dart
@@ -5,7 +5,6 @@
 import 'having_matcher.dart';
 import 'interfaces.dart';
 
-
 /// Returns a matcher that matches objects with type [T].
 ///
 /// ```dart

--- a/test/type_matcher_test.dart
+++ b/test/type_matcher_test.dart
@@ -30,6 +30,7 @@ void main() {
     _test('String', const isInstanceOf<String>(), 'hello');
     _test('String', const _StringMatcher(), 'hello');
     _test('String', const TypeMatcher<String>(), 'hello');
+    _test('String', isA<String>(), 'hello');
   });
 }
 


### PR DESCRIPTION
Closes #103
Closes #98

`isA` is a shorter name that reads just as nicely as `isInstanceOf` and
gives a path for an incremental migration to using a method instead of a
class.