### PR TITLE
Fixes for analysis and Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: dart
 
 dart:
-  - 2.0.0
+  - 2.2.0
   - dev
 
 dart_task:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@ matrix:
   - dart: dev
     dart_task: dartfmt
 
+# Only building master means that we don't run two builds for each pull request.
+branches:
+  only: [master]
+
 cache:
   directories:
     - $HOME/.pub-cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,20 @@
 language: dart
 
 dart:
+  - 2.0.0
   - dev
 
 dart_task:
   - test: -p vm
     xvfb: false
   - test: -p firefox
-  - dartanalyzer
-  - dartfmt
+  - dartanalyzer: --fatal-infos --fatal-warnings .
 
-# Only building master means that we don't run two builds for each pull request.
-branches:
-  only: [master]
+matrix:
+  include:
+  # Only validate formatting using the dev release
+  - dart: dev
+    dart_task: dartfmt
 
 cache:
   directories:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.12.6
+
+- Update minimum Dart SDK to `2.2.0`.
+
 ## 0.12.5
 
 - Add `isA()` to create `TypeMatcher` instances in a more fluent way.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,7 @@
 ## 0.12.0
 
 * Moved a number of members to the
-  [`unittest`](https://pub.dartlang.org/packages/unittest) package.
+  [`unittest`](https://pub.dev/packages/unittest) package.
   * `TestFailure`, `ErrorFormatter`, `expect`, `fail`, and 'wrapAsync'.
   * `completes`, `completion`, `throws`, and `throwsA` Matchers.
   * The `Throws` class.

--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ The matcher library provides a third-generation assertion mechanism, drawing
 inspiration from [Hamcrest](https://code.google.com/p/hamcrest/).
 
 For more information, see
-[Unit Testing with Dart](https://www.dartlang.org/articles/dart-unit-tests/).
+[Unit Testing with Dart](https://github.com/dart-lang/test/blob/master/pkgs/test/README.md#writing-tests).

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -52,12 +52,14 @@ linter:
     - package_names
     - package_prefixed_library_names
     - prefer_adjacent_string_concatenation
-    - prefer_collection_literals
+    # Ignoring until min SDK is 2.2
+    #- prefer_collection_literals
     - prefer_conditional_assignment
     - prefer_const_constructors
     - prefer_contains
     - prefer_equal_for_default_values
     - prefer_final_fields
+    - prefer_generic_function_type_aliases
     - prefer_initializing_formals
     #- prefer_interpolation_to_compose_strings
     - prefer_is_empty
@@ -66,7 +68,6 @@ linter:
     - prefer_typing_uninitialized_variables
     - recursive_getters
     - slash_for_doc_comments
-    - super_goes_last
     - test_types_in_equals
     - throw_in_finally
     - type_init_formals

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -52,8 +52,7 @@ linter:
     - package_names
     - package_prefixed_library_names
     - prefer_adjacent_string_concatenation
-    # Ignoring until min SDK is 2.2
-    #- prefer_collection_literals
+    - prefer_collection_literals
     - prefer_conditional_assignment
     - prefer_const_constructors
     - prefer_contains

--- a/codereview.settings
+++ b/codereview.settings
@@ -1,3 +1,0 @@
-CODE_REVIEW_SERVER: https://codereview.chromium.org/
-VIEW_VC: https://github.com/dart-lang/matcher/commit/
-CC_LIST: reviews@dartlang.org

--- a/lib/src/equals_matcher.dart
+++ b/lib/src/equals_matcher.dart
@@ -70,7 +70,9 @@ class _StringEqualsMatcher extends FeatureMatcher<String> {
       _writeLeading(buff, escapedItem, start);
       _writeTrailing(buff, escapedItem, start);
       buff.write('\n          ');
-      for (var i = start > 10 ? 14 : start; i > 0; i--) buff.write(' ');
+      for (var i = start > 10 ? 14 : start; i > 0; i--) {
+        buff.write(' ');
+      }
       buff.write('^\n Differ at offset $start');
     }
 

--- a/lib/src/iterable_matchers.dart
+++ b/lib/src/iterable_matchers.dart
@@ -214,7 +214,7 @@ class _UnorderedMatches extends _IterableMatcher {
   /// tracks the matchers that have been used _during_ this search.
   bool _findPairing(List<List<int>> edges, int valueIndex, List<int> matched,
       [Set<int> reserved]) {
-    reserved ??= Set<int>();
+    reserved ??= <int>{};
     final possiblePairings =
         edges[valueIndex].where((m) => !reserved.contains(m));
     for (final matcherIndex in possiblePairings) {

--- a/lib/src/pretty_print.dart
+++ b/lib/src/pretty_print.dart
@@ -26,7 +26,7 @@ String prettyPrint(object, {int maxLineLength, int maxItems}) {
 
     // Avoid looping infinitely on recursively-nested data structures.
     if (seen.contains(object)) return "(recursive)";
-    seen = seen.union(Set.from([object]));
+    seen = seen.union({object});
     String pp(child) => _prettyPrint(child, indent + 2, seen, false);
 
     if (object is Iterable) {
@@ -113,7 +113,7 @@ String prettyPrint(object, {int maxLineLength, int maxItems}) {
     }
   }
 
-  return _prettyPrint(object, 0, Set(), true);
+  return _prettyPrint(object, 0, <Object>{}, true);
 }
 
 String _indent(int length) => List.filled(length, ' ').join('');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: matcher
-version: 0.12.5
+version: 0.12.6-dev
 
 description: >-
   Support for specifying test expectations via an extensible Matcher class.
@@ -8,7 +8,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/matcher
 
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.2.0 <3.0.0'
 
 dependencies:
   stack_trace: ^1.2.0


### PR DESCRIPTION
- test on oldest support Dart SDK
- remove unneeded codereview.settings
- Fix latest pedantic lints
- Add prefer_generic_function_type_aliases
- Remove deprecated super_goes_last
- Ignore prefer_collection_literals – waiting until min SDK is 2.2