### PR TITLE
Add pairwiseMatch, like pairwiseCompare but taking a matcher generator.

### DIFF
--- a/lib/src/iterable_matchers.dart
+++ b/lib/src/iterable_matchers.dart
@@ -288,12 +288,11 @@ class _PairwiseCompare<S, T> extends _IterableMatcher {
   }
 }
 
-/// A pairwise matcher for [Iterable]s.
+/// Returns a pairwise matcher for [Iterable]s.
 ///
-/// For each pair of elements from the actual and expected lists in order, we
-/// check the actual element against a matcher created by applying
-/// [elementMatcher] to the expected element. The per-element matchers are
-/// created during the construction of the Matcher.
+/// The [elementMatcher] function, taking an expected argument and returning
+/// a Matcher for the corresponding actual element, is applied to each element
+/// of [expected] once, during the construction of the pairwise matcher.
 Matcher pairwiseMatch<S, T>(
         Iterable<T> expected, Matcher Function(T) elementMatcher) =>
     _PairwiseMatcher(expected, elementMatcher);

--- a/lib/src/iterable_matchers.dart
+++ b/lib/src/iterable_matchers.dart
@@ -294,8 +294,8 @@ class _PairwiseCompare<S, T> extends _IterableMatcher {
 /// check the actual element against a matcher created by applying
 /// [elementMatcher] to the expected element. The per-element matchers are
 /// created during the construction of the Matcher.
-Matcher pairwiseMatch<S, T>(Iterable<T> expected,
-        Matcher elementMatcher(T a)) =>
+Matcher pairwiseMatch<S, T>(
+        Iterable<T> expected, Matcher elementMatcher(T a)) =>
     _PairwiseMatcher(expected, elementMatcher);
 
 typedef _ElementMatcher<T> = Matcher Function(T a);
@@ -303,7 +303,7 @@ typedef _ElementMatcher<T> = Matcher Function(T a);
 class _PairwiseMatcher<S, T> extends _IterableMatcher {
   final Iterable<Matcher> _matchers;
 
-  _PairwiseMatcher(Iterable<T>_expected, _ElementMatcher<T> _elementMatcher)
+  _PairwiseMatcher(Iterable<T> _expected, _ElementMatcher<T> _elementMatcher)
       : _matchers = _expected.map(_elementMatcher);
 
   @override
@@ -325,7 +325,7 @@ class _PairwiseMatcher<S, T> extends _IterableMatcher {
 
   @override
   Description describe(Description description) =>
-    description.addAll('[', ', ', ']', _matchers);
+      description.addAll('[', ', ', ']', _matchers);
 
   @override
   Description describeTypedMismatch(Iterable item,
@@ -335,16 +335,12 @@ class _PairwiseMatcher<S, T> extends _IterableMatcher {
           .add('has length ${item.length} instead of ${_matchers.length}');
     } else {
       return matchState["matcher"]
-          .describeMismatch(
-              matchState["actual"],
-              mismatchDescription,
-              matchState["state"],
-              verbose)
+          .describeMismatch(matchState["actual"], mismatchDescription,
+              matchState["state"], verbose)
           .add(' at index ${matchState["index"]}');
     }
   }
 }
-
 
 /// Matches [Iterable]s which contain an element matching every value in
 /// [expected] in any order, and may contain additional values.

--- a/lib/src/iterable_matchers.dart
+++ b/lib/src/iterable_matchers.dart
@@ -295,7 +295,7 @@ class _PairwiseCompare<S, T> extends _IterableMatcher {
 /// [elementMatcher] to the expected element. The per-element matchers are
 /// created during the construction of the Matcher.
 Matcher pairwiseMatch<S, T>(
-        Iterable<T> expected, Matcher elementMatcher(T a)) =>
+        Iterable<T> expected, Matcher Function(T) elementMatcher) =>
     _PairwiseMatcher(expected, elementMatcher);
 
 typedef _ElementMatcher<T> = Matcher Function(T a);
@@ -334,10 +334,10 @@ class _PairwiseMatcher<S, T> extends _IterableMatcher {
       return mismatchDescription
           .add('has length ${item.length} instead of ${_matchers.length}');
     } else {
-      return matchState["matcher"]
-          .describeMismatch(matchState["actual"], mismatchDescription,
-              matchState["state"], verbose)
-          .add(' at index ${matchState["index"]}');
+      return matchState['matcher']
+          .describeMismatch(matchState['actual'], mismatchDescription,
+              matchState['state'], verbose)
+          .add(' at index ${matchState['index']}');
     }
   }
 }

--- a/test/iterable_matchers_test.dart
+++ b/test/iterable_matchers_test.dart
@@ -325,6 +325,76 @@ void main() {
         endsWith('not an <Instance of \'Iterable\'>'));
   });
 
+  test('pairwise match', () {
+    var c = [1, 2];
+    var d = [1, 2, 3];
+    var e = [1, 4, 9];
+    var squareRoot = (int e) => predicate((a) => a * a == e, "square root of");
+    var isDouble = (int e) => predicate((a) => a + a == e, "double");
+    shouldFail(
+        'x',
+        pairwiseMatch(e, lessThanOrEqualTo),
+        "Expected: pairwise [a value less than or equal to <1>, "
+        "a value less than or equal to <4>, "
+        "a value less than or equal to <9>] "
+        "Actual: 'x' "
+        "Which: not an <Instance of \'Iterable\'>");
+    shouldFail(
+        c,
+        pairwiseMatch(e, lessThanOrEqualTo),
+        "Expected: pairwise [a value less than or equal to <1>, "
+        "a value less than or equal to <4>, "
+        "a value less than or equal to <9>] "
+        "Actual: [1, 2] "
+        "Which: has length 2 instead of 3");
+    shouldPass(
+        d, pairwiseMatch(e, lessThanOrEqualTo));
+    shouldFail(
+        d,
+        pairwiseMatch(e, lessThan),
+        "Expected: pairwise [a value less than <1>, "
+        "a value less than <4>, "
+        "a value less than <9>] "
+        "Actual: [1, 2, 3] "
+        "Which: is not a value less than <1> at index 0");
+    shouldPass(d, pairwiseMatch(e, squareRoot));
+    shouldFail(
+        d,
+        pairwiseMatch(e, isDouble),
+        "Expected: pairwise [double, double, double] "
+        "Actual: [1, 2, 3] "
+        "Which: at index 0");
+    shouldFail(
+        'not an iterable',
+        pairwiseMatch(e, isDouble),
+        endsWith('not an <Instance of \'Iterable\'>'));
+    var f = [[2, 4], [6, 8], [10, 12]];
+    var g = [[2, 4], [], [10, 12]];
+    var h = [[2, 4], [], [6, 8]];
+    shouldPass(g, pairwiseMatch(f, (e) => anyOf(isEmpty, equals(e))));
+    shouldFail(h, pairwiseMatch(f, (e) => anyOf(isEmpty, equals(e))),
+        "Expected: pairwise [(empty or [2, 4]), (empty or [6, 8]), "
+        "(empty or [10, 12])] "
+        "Actual: [[2, 4], [], [6, 8]] "
+        "Which: at index 2");
+    var i = [[1, 2], [3, 4], [5, 6]];
+    var j = [[1, 2], [8, 4], [5, 6]];
+    shouldPass(i, pairwiseMatch(f, (l) => pairwiseMatch(l, isDouble)));
+    shouldFail(j, pairwiseMatch(f, (l) => pairwiseMatch(l, isDouble)),
+        "Expected: pairwise [pairwise [double, double], "
+        "pairwise [double, double], pairwise [double, double]] "
+        "Actual: [[1, 2], [8, 4], [5, 6]] "
+        "Which: at index 0 at index 1");
+    shouldPass(i, pairwiseMatch(f, (l) => pairwiseMatch(l, lessThan)));
+    shouldFail(j, pairwiseMatch(f, (l) => pairwiseMatch(l, lessThan)),
+        "Expected: pairwise ["
+        "pairwise [a value less than <2>, a value less than <4>], "
+        "pairwise [a value less than <6>, a value less than <8>], "
+        "pairwise [a value less than <10>, a value less than <12>]] "
+        "Actual: [[1, 2], [8, 4], [5, 6]] "
+        "Which: is not a value less than <6> at index 0 at index 1");
+  });
+
   test('isEmpty', () {
     var d = SimpleIterable(0);
     var e = SimpleIterable(1);

--- a/test/iterable_matchers_test.dart
+++ b/test/iterable_matchers_test.dart
@@ -335,10 +335,10 @@ void main() {
         'x',
         pairwiseMatch(e, lessThanOrEqualTo),
         "Expected: [a value less than or equal to <1>, "
-        "a value less than or equal to <4>, "
-        "a value less than or equal to <9>] "
-        "Actual: 'x' "
-        "Which: not an <Instance of \'Iterable\'>");
+            "a value less than or equal to <4>, "
+            "a value less than or equal to <9>] "
+            "Actual: 'x' "
+            "Which: not an <Instance of \'Iterable\'>");
     shouldFail(
         c,
         pairwiseMatch(e, lessThanOrEqualTo),
@@ -347,8 +347,7 @@ void main() {
         "a value less than or equal to <9>] "
         "Actual: [1, 2] "
         "Which: has length 2 instead of 3");
-    shouldPass(
-        d, pairwiseMatch(e, lessThanOrEqualTo));
+    shouldPass(d, pairwiseMatch(e, lessThanOrEqualTo));
     shouldFail(
         d,
         pairwiseMatch(e, lessThan),
@@ -363,27 +362,51 @@ void main() {
         "Expected: [double, double, double] "
         "Actual: [1, 2, 3] "
         "Which: at index 0");
-    shouldFail(
-        'not an iterable',
-        pairwiseMatch(e, isDouble),
+    shouldFail('not an iterable', pairwiseMatch(e, isDouble),
         endsWith('not an <Instance of \'Iterable\'>'));
-    var f = [[2, 4], [6, 8], [10, 12]];
-    var g = [[2, 4], [], [10, 12]];
-    var h = [[2, 4], [], [6, 8]];
+    var f = [
+      [2, 4],
+      [6, 8],
+      [10, 12]
+    ];
+    var g = [
+      [2, 4],
+      [],
+      [10, 12]
+    ];
+    var h = [
+      [2, 4],
+      [],
+      [6, 8]
+    ];
     shouldPass(g, pairwiseMatch(f, (e) => anyOf(isEmpty, equals(e))));
-    shouldFail(h, pairwiseMatch(f, (e) => anyOf(isEmpty, equals(e))),
+    shouldFail(
+        h,
+        pairwiseMatch(f, (e) => anyOf(isEmpty, equals(e))),
         "Expected: [(empty or [2, 4]), (empty or [6, 8]), (empty or [10, 12])] "
         "Actual: [[2, 4], [], [6, 8]] "
         "Which: at index 2");
-    var i = [[1, 2], [3, 4], [5, 6]];
-    var j = [[1, 2], [8, 4], [5, 6]];
+    var i = [
+      [1, 2],
+      [3, 4],
+      [5, 6]
+    ];
+    var j = [
+      [1, 2],
+      [8, 4],
+      [5, 6]
+    ];
     shouldPass(i, pairwiseMatch(f, (l) => pairwiseMatch(l, isDouble)));
-    shouldFail(j, pairwiseMatch(f, (l) => pairwiseMatch(l, isDouble)),
+    shouldFail(
+        j,
+        pairwiseMatch(f, (l) => pairwiseMatch(l, isDouble)),
         "Expected: [[double, double], [double, double], [double, double]] "
         "Actual: [[1, 2], [8, 4], [5, 6]] "
         "Which: at index 0 at index 1");
     shouldPass(i, pairwiseMatch(f, (l) => pairwiseMatch(l, lessThan)));
-    shouldFail(j, pairwiseMatch(f, (l) => pairwiseMatch(l, lessThan)),
+    shouldFail(
+        j,
+        pairwiseMatch(f, (l) => pairwiseMatch(l, lessThan)),
         "Expected: [[a value less than <2>, a value less than <4>], "
         "[a value less than <6>, a value less than <8>], "
         "[a value less than <10>, a value less than <12>]] "

--- a/test/iterable_matchers_test.dart
+++ b/test/iterable_matchers_test.dart
@@ -329,39 +329,39 @@ void main() {
     var c = [1, 2];
     var d = [1, 2, 3];
     var e = [1, 4, 9];
-    var squareRoot = (int e) => predicate((a) => a * a == e, "square root of");
-    var isDouble = (int e) => predicate((a) => a + a == e, "double");
+    var squareRoot = (int e) => predicate((a) => a * a == e, 'square root of');
+    var isDouble = (int e) => predicate((a) => a + a == e, 'double');
     shouldFail(
         'x',
         pairwiseMatch(e, lessThanOrEqualTo),
-        "Expected: [a value less than or equal to <1>, "
-            "a value less than or equal to <4>, "
-            "a value less than or equal to <9>] "
-            "Actual: 'x' "
-            "Which: not an <Instance of \'Iterable\'>");
+        'Expected: [a value less than or equal to <1>, '
+            'a value less than or equal to <4>, '
+            'a value less than or equal to <9>] '
+            "Actual: \'x\' "
+            'Which: not an <Instance of \'Iterable\'>');
     shouldFail(
         c,
         pairwiseMatch(e, lessThanOrEqualTo),
-        "Expected: [a value less than or equal to <1>, "
-        "a value less than or equal to <4>, "
-        "a value less than or equal to <9>] "
-        "Actual: [1, 2] "
-        "Which: has length 2 instead of 3");
+        'Expected: [a value less than or equal to <1>, '
+        'a value less than or equal to <4>, '
+        'a value less than or equal to <9>] '
+        'Actual: [1, 2] '
+        'Which: has length 2 instead of 3');
     shouldPass(d, pairwiseMatch(e, lessThanOrEqualTo));
     shouldFail(
         d,
         pairwiseMatch(e, lessThan),
-        "Expected: [a value less than <1>, a value less than <4>, "
-        "a value less than <9>] "
-        "Actual: [1, 2, 3] "
-        "Which: is not a value less than <1> at index 0");
+        'Expected: [a value less than <1>, a value less than <4>, '
+        'a value less than <9>] '
+        'Actual: [1, 2, 3] '
+        'Which: is not a value less than <1> at index 0');
     shouldPass(d, pairwiseMatch(e, squareRoot));
     shouldFail(
         d,
         pairwiseMatch(e, isDouble),
-        "Expected: [double, double, double] "
-        "Actual: [1, 2, 3] "
-        "Which: at index 0");
+        'Expected: [double, double, double] '
+        'Actual: [1, 2, 3] '
+        'Which: at index 0');
     shouldFail('not an iterable', pairwiseMatch(e, isDouble),
         endsWith('not an <Instance of \'Iterable\'>'));
     var f = [
@@ -383,9 +383,9 @@ void main() {
     shouldFail(
         h,
         pairwiseMatch(f, (e) => anyOf(isEmpty, equals(e))),
-        "Expected: [(empty or [2, 4]), (empty or [6, 8]), (empty or [10, 12])] "
-        "Actual: [[2, 4], [], [6, 8]] "
-        "Which: at index 2");
+        'Expected: [(empty or [2, 4]), (empty or [6, 8]), (empty or [10, 12])] '
+        'Actual: [[2, 4], [], [6, 8]] '
+        'Which: at index 2');
     var i = [
       [1, 2],
       [3, 4],
@@ -400,18 +400,18 @@ void main() {
     shouldFail(
         j,
         pairwiseMatch(f, (l) => pairwiseMatch(l, isDouble)),
-        "Expected: [[double, double], [double, double], [double, double]] "
-        "Actual: [[1, 2], [8, 4], [5, 6]] "
-        "Which: at index 0 at index 1");
+        'Expected: [[double, double], [double, double], [double, double]] '
+        'Actual: [[1, 2], [8, 4], [5, 6]] '
+        'Which: at index 0 at index 1');
     shouldPass(i, pairwiseMatch(f, (l) => pairwiseMatch(l, lessThan)));
     shouldFail(
         j,
         pairwiseMatch(f, (l) => pairwiseMatch(l, lessThan)),
-        "Expected: [[a value less than <2>, a value less than <4>], "
-        "[a value less than <6>, a value less than <8>], "
-        "[a value less than <10>, a value less than <12>]] "
-        "Actual: [[1, 2], [8, 4], [5, 6]] "
-        "Which: is not a value less than <6> at index 0 at index 1");
+        'Expected: [[a value less than <2>, a value less than <4>], '
+        '[a value less than <6>, a value less than <8>], '
+        '[a value less than <10>, a value less than <12>]] '
+        'Actual: [[1, 2], [8, 4], [5, 6]] '
+        'Which: is not a value less than <6> at index 0 at index 1');
   });
 
   test('isEmpty', () {

--- a/test/iterable_matchers_test.dart
+++ b/test/iterable_matchers_test.dart
@@ -334,7 +334,7 @@ void main() {
     shouldFail(
         'x',
         pairwiseMatch(e, lessThanOrEqualTo),
-        "Expected: pairwise [a value less than or equal to <1>, "
+        "Expected: [a value less than or equal to <1>, "
         "a value less than or equal to <4>, "
         "a value less than or equal to <9>] "
         "Actual: 'x' "
@@ -342,7 +342,7 @@ void main() {
     shouldFail(
         c,
         pairwiseMatch(e, lessThanOrEqualTo),
-        "Expected: pairwise [a value less than or equal to <1>, "
+        "Expected: [a value less than or equal to <1>, "
         "a value less than or equal to <4>, "
         "a value less than or equal to <9>] "
         "Actual: [1, 2] "
@@ -352,8 +352,7 @@ void main() {
     shouldFail(
         d,
         pairwiseMatch(e, lessThan),
-        "Expected: pairwise [a value less than <1>, "
-        "a value less than <4>, "
+        "Expected: [a value less than <1>, a value less than <4>, "
         "a value less than <9>] "
         "Actual: [1, 2, 3] "
         "Which: is not a value less than <1> at index 0");
@@ -361,7 +360,7 @@ void main() {
     shouldFail(
         d,
         pairwiseMatch(e, isDouble),
-        "Expected: pairwise [double, double, double] "
+        "Expected: [double, double, double] "
         "Actual: [1, 2, 3] "
         "Which: at index 0");
     shouldFail(
@@ -373,24 +372,21 @@ void main() {
     var h = [[2, 4], [], [6, 8]];
     shouldPass(g, pairwiseMatch(f, (e) => anyOf(isEmpty, equals(e))));
     shouldFail(h, pairwiseMatch(f, (e) => anyOf(isEmpty, equals(e))),
-        "Expected: pairwise [(empty or [2, 4]), (empty or [6, 8]), "
-        "(empty or [10, 12])] "
+        "Expected: [(empty or [2, 4]), (empty or [6, 8]), (empty or [10, 12])] "
         "Actual: [[2, 4], [], [6, 8]] "
         "Which: at index 2");
     var i = [[1, 2], [3, 4], [5, 6]];
     var j = [[1, 2], [8, 4], [5, 6]];
     shouldPass(i, pairwiseMatch(f, (l) => pairwiseMatch(l, isDouble)));
     shouldFail(j, pairwiseMatch(f, (l) => pairwiseMatch(l, isDouble)),
-        "Expected: pairwise [pairwise [double, double], "
-        "pairwise [double, double], pairwise [double, double]] "
+        "Expected: [[double, double], [double, double], [double, double]] "
         "Actual: [[1, 2], [8, 4], [5, 6]] "
         "Which: at index 0 at index 1");
     shouldPass(i, pairwiseMatch(f, (l) => pairwiseMatch(l, lessThan)));
     shouldFail(j, pairwiseMatch(f, (l) => pairwiseMatch(l, lessThan)),
-        "Expected: pairwise ["
-        "pairwise [a value less than <2>, a value less than <4>], "
-        "pairwise [a value less than <6>, a value less than <8>], "
-        "pairwise [a value less than <10>, a value less than <12>]] "
+        "Expected: [[a value less than <2>, a value less than <4>], "
+        "[a value less than <6>, a value less than <8>], "
+        "[a value less than <10>, a value less than <12>]] "
         "Actual: [[1, 2], [8, 4], [5, 6]] "
         "Which: is not a value less than <6> at index 0 at index 1");
   });


### PR DESCRIPTION
Instead of simply taking a comparison predicate that is applied pairwise, pairwiseMatch
takes a function that generates matchers for each element of the expected iterator, and
then checks those matchers in order for the elements of the gotten iterator.

pairwiseCompose could be rewritten in terms of _PairwiseMatcher, but that is not done
here since the most straightforward way of doing so would change the error message:

```dart
import 'package:matcher/matcher.dart';

void main() {
  final desc1 = StringDescription();
  pairwiseCompare([1, 2, 3], (a, e) => a + a == e, "double").describe(desc1);
  print(desc1); // ==> "pairwise double [1, 2, 3]"

  // Use the description of the predicate as given to pairwiseCompose
  final desc2 = StringDescription();
  pairwiseMatch([1, 2, 3],
      (e) => predicate((a) => a + a == e, "double")).describe(desc2);
  print(desc2); // ==> "[double, double, double]"

  // Alternative version that adds the expected value to the description
  final desc3 = StringDescription();
  pairwiseMatch([1, 2, 3],
      (e) => predicate((a) => a + a == e, "double ${e}")).describe(desc3);
  print(desc3); // ==> "[double 1, double 2, double 3]"
}
```