### PR TITLE
Fix newly enforced package:pedantic lints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: dart
 
 dart:
-  - 2.2.0
+  - 2.3.0
   - dev
 
 dart_task:

--- a/lib/src/core_matchers.dart
+++ b/lib/src/core_matchers.dart
@@ -160,7 +160,7 @@ class _ReturnsNormally extends FeatureMatcher<Function> {
 
   @override
   Description describe(Description description) =>
-      description.add("return normally");
+      description.add('return normally');
 
   @override
   Description describeTypedMismatch(Function item,
@@ -305,7 +305,7 @@ class _In<T> extends FeatureMatcher<T> {
 /// For example:
 ///
 ///     expect(v, predicate((x) => ((x % 2) == 0), "is even"))
-Matcher predicate<T>(bool f(T value),
+Matcher predicate<T>(bool Function(T) f,
         [String description = 'satisfies function']) =>
     _Predicate(f, description);
 

--- a/lib/src/equals_matcher.dart
+++ b/lib/src/equals_matcher.dart
@@ -228,7 +228,7 @@ class _DeepMatcher extends Matcher {
     }
 
     // We're not adding any value to the actual value.
-    return ["", location];
+    return ['', location];
   }
 
   String _match(expected, actual, Map matchState) {
@@ -237,7 +237,7 @@ class _DeepMatcher extends Matcher {
     String reason;
     if (rp[0].isNotEmpty) {
       if (rp[1].isNotEmpty) {
-        reason = "${rp[0]} at location ${rp[1]}";
+        reason = '${rp[0]} at location ${rp[1]}';
       } else {
         reason = rp[0];
       }

--- a/lib/src/having_matcher.dart
+++ b/lib/src/having_matcher.dart
@@ -14,16 +14,17 @@ class HavingMatcher<T> implements TypeMatcher<T> {
   final List<_FunctionMatcher> _functionMatchers;
 
   HavingMatcher(TypeMatcher<T> parent, String description,
-      Object feature(T source), Object matcher,
+      Object Function(T) feature, Object matcher,
       [Iterable<_FunctionMatcher> existing])
       : _parent = parent,
-        _functionMatchers = <_FunctionMatcher>[]
-          ..addAll(existing ?? [])
-          ..add(_FunctionMatcher<T>(description, feature, matcher));
+        _functionMatchers = <_FunctionMatcher>[
+          ...?existing,
+          _FunctionMatcher<T>(description, feature, matcher)
+        ];
 
   @override
   TypeMatcher<T> having(
-          Object feature(T source), String description, Object matcher) =>
+          Object Function(T) feature, String description, Object matcher) =>
       HavingMatcher(_parent, description, feature, matcher, _functionMatchers);
 
   @override

--- a/lib/src/iterable_matchers.dart
+++ b/lib/src/iterable_matchers.dart
@@ -237,8 +237,8 @@ class _UnorderedMatches extends _IterableMatcher {
 /// The [comparator] function, taking an expected and an actual argument, and
 /// returning whether they match, will be applied to each pair in order.
 /// [description] should be a meaningful name for the comparator.
-Matcher pairwiseCompare<S, T>(
-        Iterable<S> expected, bool comparator(S a, T b), String description) =>
+Matcher pairwiseCompare<S, T>(Iterable<S> expected,
+        bool Function(S, T) comparator, String description) =>
     _PairwiseCompare(expected, comparator, description);
 
 typedef _Comparator<S, T> = bool Function(S a, T b);
@@ -280,9 +280,9 @@ class _PairwiseCompare<S, T> extends _IterableMatcher {
     } else {
       return mismatchDescription
           .add('has ')
-          .addDescriptionOf(matchState["actual"])
+          .addDescriptionOf(matchState['actual'])
           .add(' which is not $_description ')
-          .addDescriptionOf(matchState["expected"])
+          .addDescriptionOf(matchState['expected'])
           .add(' at index ${matchState["index"]}');
     }
   }

--- a/lib/src/numeric_matchers.dart
+++ b/lib/src/numeric_matchers.dart
@@ -83,7 +83,7 @@ class _InRange extends FeatureMatcher<num> {
 
   @override
   Description describe(Description description) =>
-      description.add("be in range from "
+      description.add('be in range from '
           "$_low (${_lowMatchValue ? 'inclusive' : 'exclusive'}) to "
           "$_high (${_highMatchValue ? 'inclusive' : 'exclusive'})");
 }

--- a/lib/src/pretty_print.dart
+++ b/lib/src/pretty_print.dart
@@ -21,17 +21,17 @@ String prettyPrint(object, {int maxLineLength, int maxItems}) {
     if (object is Matcher) {
       var description = StringDescription();
       object.describe(description);
-      return "<$description>";
+      return '<$description>';
     }
 
     // Avoid looping infinitely on recursively-nested data structures.
-    if (seen.contains(object)) return "(recursive)";
+    if (seen.contains(object)) return '(recursive)';
     seen = seen.union({object});
     String pp(child) => _prettyPrint(child, indent + 2, seen, false);
 
     if (object is Iterable) {
       // Print the type name for non-List iterables.
-      var type = object is List ? "" : _typeName(object) + ":";
+      var type = object is List ? '' : _typeName(object) + ':';
 
       // Truncate the list of strings if it's longer than [maxItems].
       var strings = object.map(pp).toList();
@@ -44,18 +44,18 @@ String prettyPrint(object, {int maxLineLength, int maxItems}) {
       var singleLine = "$type[${strings.join(', ')}]";
       if ((maxLineLength == null ||
               singleLine.length + indent <= maxLineLength) &&
-          !singleLine.contains("\n")) {
+          !singleLine.contains('\n')) {
         return singleLine;
       }
 
       // Otherwise, print each member on its own line.
-      return "$type[\n" +
+      return '$type[\n' +
           strings.map((string) {
             return _indent(indent + 2) + string;
-          }).join(",\n") +
-          "\n" +
+          }).join(',\n') +
+          '\n' +
           _indent(indent) +
-          "]";
+          ']';
     } else if (object is Map) {
       // Convert the contents of the map to string representations.
       var strings = object.keys.map((key) {
@@ -69,34 +69,34 @@ String prettyPrint(object, {int maxLineLength, int maxItems}) {
 
       // If the printed string is short and doesn't contain a newline, print it
       // as a single line.
-      var singleLine = "{${strings.join(", ")}}";
+      var singleLine = '{${strings.join(", ")}}';
       if ((maxLineLength == null ||
               singleLine.length + indent <= maxLineLength) &&
-          !singleLine.contains("\n")) {
+          !singleLine.contains('\n')) {
         return singleLine;
       }
 
       // Otherwise, print each key/value pair on its own line.
-      return "{\n" +
+      return '{\n' +
           strings.map((string) {
             return _indent(indent + 2) + string;
-          }).join(",\n") +
-          "\n" +
+          }).join(',\n') +
+          '\n' +
           _indent(indent) +
-          "}";
+          '}';
     } else if (object is String) {
       // Escape strings and print each line on its own line.
-      var lines = object.split("\n");
+      var lines = object.split('\n');
       return "'" +
           lines.map(_escapeString).join("\\n'\n${_indent(indent + 2)}'") +
           "'";
     } else {
-      var value = object.toString().replaceAll("\n", _indent(indent) + "\n");
-      var defaultToString = value.startsWith("Instance of ");
+      var value = object.toString().replaceAll('\n', _indent(indent) + '\n');
+      var defaultToString = value.startsWith('Instance of ');
 
       // If this is the top-level call to [prettyPrint], wrap the value on angle
       // brackets to set it apart visually.
-      if (top) value = "<$value>";
+      if (top) value = '<$value>';
 
       // Print the type of objects with custom [toString] methods. Primitive
       // objects and objects that don't implement a custom [toString] don't need
@@ -111,7 +111,7 @@ String prettyPrint(object, {int maxLineLength, int maxItems}) {
           defaultToString) {
         return value;
       } else {
-        return "${_typeName(object)}:$value";
+        return '${_typeName(object)}:$value';
       }
     }
   }
@@ -124,10 +124,10 @@ String _indent(int length) => List.filled(length, ' ').join('');
 /// Returns the name of the type of [x] with fallbacks for core types with
 /// private implementations.
 String _typeName(x) {
-  if (x is Type) return "Type";
-  if (x is Uri) return "Uri";
-  if (x is Set) return "Set";
-  if (x is BigInt) return "BigInt";
+  if (x is Type) return 'Type';
+  if (x is Uri) return 'Uri';
+  if (x is Set) return 'Set';
+  if (x is BigInt) return 'BigInt';
   return '${x.runtimeType}';
 }
 

--- a/lib/src/string_matchers.dart
+++ b/lib/src/string_matchers.dart
@@ -47,12 +47,10 @@ Matcher equalsIgnoringWhitespace(String value) =>
     _IsEqualIgnoringWhitespace(value);
 
 class _IsEqualIgnoringWhitespace extends FeatureMatcher<String> {
-  final String _value;
   final String _matchValue;
 
   _IsEqualIgnoringWhitespace(String value)
-      : _value = value,
-        _matchValue = collapseWhitespace(value);
+      : _matchValue = collapseWhitespace(value);
 
   @override
   bool typedMatches(String item, Map matchState) =>

--- a/lib/src/type_matcher.dart
+++ b/lib/src/type_matcher.dart
@@ -80,7 +80,7 @@ class TypeMatcher<T> extends Matcher {
   ///    .having((e) => e.end, 'end', isNull);
   /// ```
   TypeMatcher<T> having(
-          Object feature(T source), String description, Object matcher) =>
+          Object Function(T) feature, String description, Object matcher) =>
       HavingMatcher(this, description, feature, matcher);
 
   @override

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -21,7 +21,7 @@ const _escapeMap = {
 
 /// A [RegExp] that matches whitespace characters that should be escaped.
 final _escapeRegExp = RegExp(
-    "[\\x00-\\x07\\x0E-\\x1F${_escapeMap.keys.map(_getHexLiteral).join()}]");
+    '[\\x00-\\x07\\x0E-\\x1F${_escapeMap.keys.map(_getHexLiteral).join()}]');
 
 /// Useful utility for nesting match states.
 void addStateInfo(Map matchState, Map values) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,14 +1,13 @@
 name: matcher
-version: 0.12.6
+version: 0.12.7-dev
 
 description: >-
   Support for specifying test expectations via an extensible Matcher class.
   Also includes a number of built-in Matcher implementations for common cases.
-author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/matcher
 
 environment:
-  sdk: '>=2.2.0 <3.0.0'
+  sdk: '>=2.3.0 <3.0.0'
 
 dependencies:
   stack_trace: ^1.2.0

--- a/test/core_matchers_test.dart
+++ b/test/core_matchers_test.dart
@@ -10,34 +10,34 @@ import 'test_utils.dart';
 void main() {
   test('isTrue', () {
     shouldPass(true, isTrue);
-    shouldFail(false, isTrue, "Expected: true Actual: <false>");
+    shouldFail(false, isTrue, 'Expected: true Actual: <false>');
   });
 
   test('isFalse', () {
     shouldPass(false, isFalse);
-    shouldFail(10, isFalse, "Expected: false Actual: <10>");
-    shouldFail(true, isFalse, "Expected: false Actual: <true>");
+    shouldFail(10, isFalse, 'Expected: false Actual: <10>');
+    shouldFail(true, isFalse, 'Expected: false Actual: <true>');
   });
 
   test('isNull', () {
     shouldPass(null, isNull);
-    shouldFail(false, isNull, "Expected: null Actual: <false>");
+    shouldFail(false, isNull, 'Expected: null Actual: <false>');
   });
 
   test('isNotNull', () {
     shouldPass(false, isNotNull);
-    shouldFail(null, isNotNull, "Expected: not null Actual: <null>");
+    shouldFail(null, isNotNull, 'Expected: not null Actual: <null>');
   });
 
   test('isNaN', () {
     shouldPass(double.nan, isNaN);
-    shouldFail(3.1, isNaN, "Expected: NaN Actual: <3.1>");
+    shouldFail(3.1, isNaN, 'Expected: NaN Actual: <3.1>');
     shouldFail('not a num', isNaN, endsWith('not an <Instance of \'num\'>'));
   });
 
   test('isNotNaN', () {
     shouldPass(3.1, isNotNaN);
-    shouldFail(double.nan, isNotNaN, "Expected: not NaN Actual: <NaN>");
+    shouldFail(double.nan, isNotNaN, 'Expected: not NaN Actual: <NaN>');
     shouldFail('not a num', isNotNaN, endsWith('not an <Instance of \'num\'>'));
   });
 
@@ -45,7 +45,7 @@ void main() {
     var a = {};
     var b = {};
     shouldPass(a, same(a));
-    shouldFail(b, same(a), "Expected: same instance as {} Actual: {}");
+    shouldFail(b, same(a), 'Expected: same instance as {} Actual: {}');
   });
 
   test('equals', () {
@@ -66,15 +66,15 @@ void main() {
     shouldFail(
         [1, 2, 3, 4, 5, 6, 7, 8, 9],
         equals(set1),
-        matches(r"Expected: .*:\[1, 2, 3, 4, 5, 6, 7, 8, 9, 10\]"
-            r"  Actual: \[1, 2, 3, 4, 5, 6, 7, 8, 9\]"
-            r"   Which: does not contain 10"));
+        matches(r'Expected: .*:\[1, 2, 3, 4, 5, 6, 7, 8, 9, 10\]'
+            r'  Actual: \[1, 2, 3, 4, 5, 6, 7, 8, 9\]'
+            r'   Which: does not contain 10'));
     shouldFail(
         [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
         equals(set1),
-        matches(r"Expected: .*:\[1, 2, 3, 4, 5, 6, 7, 8, 9, 10\]"
-            r"  Actual: \[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11\]"
-            r"   Which: larger than expected"));
+        matches(r'Expected: .*:\[1, 2, 3, 4, 5, 6, 7, 8, 9, 10\]'
+            r'  Actual: \[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11\]'
+            r'   Which: larger than expected'));
   });
 
   test('anything', () {
@@ -82,7 +82,7 @@ void main() {
     shouldPass(0, anything);
     shouldPass(null, anything);
     shouldPass(a, anything);
-    shouldFail(a, isNot(anything), "Expected: not anything Actual: {}");
+    shouldFail(a, isNot(anything), 'Expected: not anything Actual: {}');
   });
 
   test('returnsNormally', () {
@@ -90,9 +90,9 @@ void main() {
     shouldFail(
         doesThrow,
         returnsNormally,
-        matches(r"Expected: return normally"
-            r"  Actual: <Closure.*>"
-            r"   Which: threw StateError:<Bad state: X>"));
+        matches(r'Expected: return normally'
+            r'  Actual: <Closure.*>'
+            r'   Which: threw StateError:<Bad state: X>'));
     shouldFail('not a function', returnsNormally,
         contains('not an <Instance of \'Function\'>'));
   });
@@ -106,26 +106,26 @@ void main() {
     shouldFail(
         0,
         hasLength(0),
-        "Expected: an object with length of <0> "
-        "Actual: <0> "
-        "Which: has no length property");
+        'Expected: an object with length of <0> '
+        'Actual: <0> '
+        'Which: has no length property');
 
     b.add(0);
     shouldPass(b, hasLength(1));
     shouldFail(
         b,
         hasLength(2),
-        "Expected: an object with length of <2> "
-        "Actual: [0] "
-        "Which: has length of <1>");
+        'Expected: an object with length of <2> '
+        'Actual: [0] '
+        'Which: has length of <1>');
 
     b.add(0);
     shouldFail(
         b,
         hasLength(1),
-        "Expected: an object with length of <1> "
-        "Actual: [0, 0] "
-        "Which: has length of <2>");
+        'Expected: an object with length of <1> '
+        'Actual: [0, 0] '
+        'Which: has length of <2>');
     shouldPass(b, hasLength(2));
   });
 
@@ -133,7 +133,7 @@ void main() {
     shouldFail(
         'error',
         equals(5.1),
-        "Expected: <5.1> "
+        'Expected: <5.1> '
             "Actual: 'error'");
   });
 
@@ -141,7 +141,7 @@ void main() {
     shouldFail(
         ['error'],
         equals([5.1]),
-        "Expected: [5.1] "
+        'Expected: [5.1] '
         "Actual: ['error'] "
         "Which: was 'error' instead of <5.1> at location [0]");
   });
@@ -154,7 +154,7 @@ void main() {
         equals([
           [5.1]
         ]),
-        "Expected: [[5.1]] "
+        'Expected: [[5.1]] '
         "Actual: [['error']] "
         "Which: was 'error' instead of <5.1> at location [0][0]");
   });
@@ -174,7 +174,7 @@ void main() {
     ];
     var reason1 = "Expected: [['foo', 'bar'], ['foo'], 4, []] "
         "Actual: [['foo', 'bar'], ['foo'], 3, []] "
-        "Which: was <3> instead of <4> at location [2]";
+        'Which: was <3> instead of <4> at location [2]';
 
     var actual2 = [
       ['foo', 'barry'],
@@ -215,15 +215,15 @@ void main() {
 
   group('Predicate Matchers', () {
     test('isInstanceOf', () {
-      shouldFail(0, predicate((x) => x is String, "an instance of String"),
-          "Expected: an instance of String Actual: <0>");
-      shouldPass('cow', predicate((x) => x is String, "an instance of String"));
+      shouldFail(0, predicate((x) => x is String, 'an instance of String'),
+          'Expected: an instance of String Actual: <0>');
+      shouldPass('cow', predicate((x) => x is String, 'an instance of String'));
 
       if (isDart2) {
         // With Dart2 semantics, predicate picks up a type argument of `bool`
         // and we get nice type checking.
         // Without Dart2 semantics a gnarly type error is thrown.
-        shouldFail(0, predicate((bool x) => x, "bool value is true"),
+        shouldFail(0, predicate((bool x) => x, 'bool value is true'),
             endsWith("not an <Instance of \'bool\'>"));
       }
     });

--- a/test/custom_matcher_test.dart
+++ b/test/custom_matcher_test.dart
@@ -8,19 +8,19 @@ import 'package:test/test.dart' show test;
 import 'test_utils.dart';
 
 class _BadCustomMatcher extends CustomMatcher {
-  _BadCustomMatcher() : super("feature", "description", {1: "a"});
+  _BadCustomMatcher() : super('feature', 'description', {1: 'a'});
   @override
-  Object featureValueOf(actual) => throw Exception("bang");
+  Object featureValueOf(actual) => throw Exception('bang');
 }
 
 class _HasPrice extends CustomMatcher {
-  _HasPrice(matcher) : super("Widget with a price that is", "price", matcher);
+  _HasPrice(matcher) : super('Widget with a price that is', 'price', matcher);
   @override
   Object featureValueOf(actual) => (actual as Widget).price;
 }
 
 void main() {
-  test("Feature Matcher", () {
+  test('Feature Matcher', () {
     var w = Widget();
     w.price = 10;
     shouldPass(w, _HasPrice(10));
@@ -28,15 +28,15 @@ void main() {
     shouldFail(
         w,
         _HasPrice(greaterThan(10)),
-        "Expected: Widget with a price that is a value greater than <10> "
+        'Expected: Widget with a price that is a value greater than <10> '
         "Actual: <Instance of 'Widget'> "
-        "Which: has price with value <10> which is not "
-        "a value greater than <10>");
+        'Which: has price with value <10> which is not '
+        'a value greater than <10>');
   });
 
-  test("Custom Matcher Exception", () {
+  test('Custom Matcher Exception', () {
     shouldFail(
-        "a",
+        'a',
         _BadCustomMatcher(),
         allOf([
           contains("Expected: feature {1: 'a'} "),

--- a/test/escape_test.dart
+++ b/test/escape_test.dart
@@ -40,8 +40,8 @@ void _testEscaping(String name, String source, String target) {
   test(name, () {
     var escaped = escape(source);
     expect(escaped == target, isTrue,
-        reason: "Expected escaped value: $target\n"
-            "  Actual escaped value: $escaped");
+        reason: 'Expected escaped value: $target\n'
+            '  Actual escaped value: $escaped');
   });
 }
 

--- a/test/having_test.dart
+++ b/test/having_test.dart
@@ -43,7 +43,7 @@ void main() {
   });
 
   group('CustomMater copy', () {
-    test("Feature Matcher", () {
+    test('Feature Matcher', () {
       var w = Widget();
       w.price = 10;
       shouldPass(w, _hasPrice(10));
@@ -53,11 +53,11 @@ void main() {
           _hasPrice(greaterThan(10)),
           "Expected: <Instance of 'Widget'> with `price`: a value greater than <10> "
           "Actual: <Instance of 'Widget'> "
-          "Which: has `price` with value <10> which is not "
-          "a value greater than <10>");
+          'Which: has `price` with value <10> which is not '
+          'a value greater than <10>');
     });
 
-    test("Custom Matcher Exception", () {
+    test('Custom Matcher Exception', () {
       shouldFail(
           'a',
           _badCustomMatcher(),
@@ -88,4 +88,4 @@ Matcher _hasPrice(matcher) =>
     const TypeMatcher<Widget>().having((e) => e.price, 'price', matcher);
 
 Matcher _badCustomMatcher() => const TypeMatcher<Widget>()
-    .having((e) => throw Exception("bang"), 'feature', {1: "a"});
+    .having((e) => throw Exception('bang'), 'feature', {1: 'a'});

--- a/test/iterable_matchers_test.dart
+++ b/test/iterable_matchers_test.dart
@@ -10,11 +10,11 @@ import 'test_utils.dart';
 void main() {
   test('isEmpty', () {
     shouldPass([], isEmpty);
-    shouldFail([1], isEmpty, "Expected: empty Actual: [1]");
+    shouldFail([1], isEmpty, 'Expected: empty Actual: [1]');
   });
 
   test('isNotEmpty', () {
-    shouldFail([], isNotEmpty, "Expected: non-empty Actual: []");
+    shouldFail([], isNotEmpty, 'Expected: non-empty Actual: []');
     shouldPass([1], isNotEmpty);
   });
 
@@ -24,8 +24,8 @@ void main() {
     shouldFail(
         d,
         contains(0),
-        "Expected: contains <0> "
-        "Actual: [1, 2]");
+        'Expected: contains <0> '
+        'Actual: [1, 2]');
 
     shouldFail(
         'String', contains(42), "Expected: contains <42> Actual: 'String'");
@@ -45,11 +45,11 @@ void main() {
   test('isIn', () {
     // Iterable
     shouldPass(1, isIn([1, 2]));
-    shouldFail(0, isIn([1, 2]), "Expected: is in [1, 2] Actual: <0>");
+    shouldFail(0, isIn([1, 2]), 'Expected: is in [1, 2] Actual: <0>');
 
     // Map
     shouldPass(1, isIn({1: null}));
-    shouldFail(0, isIn({1: null}), "Expected: is in {1: null} Actual: <0>");
+    shouldFail(0, isIn({1: null}), 'Expected: is in {1: null} Actual: <0>');
 
     // String
     shouldPass('42', isIn('1421'));
@@ -67,8 +67,8 @@ void main() {
     shouldFail(
         d,
         everyElement(1),
-        "Expected: every element(<1>) "
-        "Actual: [1, 2] "
+        'Expected: every element(<1>) '
+        'Actual: [1, 2] '
         "Which: has value <2> which doesn't match <1> at index 1");
     shouldPass(e, everyElement(1));
     shouldFail('not iterable', everyElement(1),
@@ -94,31 +94,31 @@ void main() {
         "Expected: every element(every element('foo')) "
         "Actual: [['foo', 'bar'], ['foo'], []] "
         "Which: has value ['foo', 'bar'] which has value 'bar' "
-        "which is different. Expected: foo Actual: bar ^ "
-        "Differ at offset 0 at index 1 at index 0");
+        'which is different. Expected: foo Actual: bar ^ '
+        'Differ at offset 0 at index 1 at index 0');
     shouldFail(
         d,
         everyElement(allOf(hasLength(greaterThan(0)), contains('foo'))),
-        "Expected: every element((an object with length of a value "
+        'Expected: every element((an object with length of a value '
         "greater than <0> and contains 'foo')) "
         "Actual: [['foo', 'bar'], ['foo'], []] "
-        "Which: has value [] which has length of <0> at index 2");
+        'Which: has value [] which has length of <0> at index 2');
     shouldFail(
         d,
         everyElement(allOf(contains('foo'), hasLength(greaterThan(0)))),
         "Expected: every element((contains 'foo' and "
-        "an object with length of a value greater than <0>)) "
+        'an object with length of a value greater than <0>)) '
         "Actual: [['foo', 'bar'], ['foo'], []] "
         "Which: has value [] which doesn't match (contains 'foo' and "
-        "an object with length of a value greater than <0>) at index 2");
+        'an object with length of a value greater than <0>) at index 2');
     shouldFail(
         e,
         everyElement(allOf(contains('foo'), hasLength(greaterThan(0)))),
         "Expected: every element((contains 'foo' and an object with "
-        "length of a value greater than <0>)) "
+        'length of a value greater than <0>)) '
         "Actual: [['foo', 'bar'], ['foo'], 3, []] "
-        "Which: has value <3> which is not a string, map or iterable "
-        "at index 2");
+        'Which: has value <3> which is not a string, map or iterable '
+        'at index 2');
   });
 
   test('anyElement', () {
@@ -126,7 +126,7 @@ void main() {
     var e = [1, 1, 1];
     shouldPass(d, anyElement(2));
     shouldFail(
-        e, anyElement(2), "Expected: some element <2> Actual: [1, 1, 1]");
+        e, anyElement(2), 'Expected: some element <2> Actual: [1, 1, 1]');
     shouldFail('not an iterable', anyElement(2),
         endsWith('not an <Instance of \'Iterable\'>'));
   });
@@ -138,9 +138,9 @@ void main() {
     shouldFail(
         d,
         orderedEquals([2, 1]),
-        "Expected: equals [2, 1] ordered "
-        "Actual: [1, 2] "
-        "Which: was <1> instead of <2> at location [0]");
+        'Expected: equals [2, 1] ordered '
+        'Actual: [1, 2] '
+        'Which: was <1> instead of <2> at location [0]');
     shouldFail('not an iterable', orderedEquals([1]),
         endsWith('not an <Instance of \'Iterable\'>'));
   });
@@ -151,28 +151,28 @@ void main() {
     shouldFail(
         d,
         unorderedEquals([1]),
-        "Expected: equals [1] unordered "
-        "Actual: [1, 2] "
-        "Which: has too many elements (2 > 1)");
+        'Expected: equals [1] unordered '
+        'Actual: [1, 2] '
+        'Which: has too many elements (2 > 1)');
     shouldFail(
         d,
         unorderedEquals([3, 2, 1]),
-        "Expected: equals [3, 2, 1] unordered "
-        "Actual: [1, 2] "
-        "Which: has too few elements (2 < 3)");
+        'Expected: equals [3, 2, 1] unordered '
+        'Actual: [1, 2] '
+        'Which: has too few elements (2 < 3)');
     shouldFail(
         d,
         unorderedEquals([3, 1]),
-        "Expected: equals [3, 1] unordered "
-        "Actual: [1, 2] "
-        "Which: has no match for <3> at index 0");
+        'Expected: equals [3, 1] unordered '
+        'Actual: [1, 2] '
+        'Which: has no match for <3> at index 0');
     shouldFail(
         d,
         unorderedEquals([3, 4]),
-        "Expected: equals [3, 4] unordered "
-        "Actual: [1, 2] "
-        "Which: has no match for <3> at index 0"
-        " along with 1 other unmatched");
+        'Expected: equals [3, 4] unordered '
+        'Actual: [1, 2] '
+        'Which: has no match for <3> at index 0'
+        ' along with 1 other unmatched');
     shouldFail('not an iterable', unorderedEquals([1]),
         endsWith('not an <Instance of \'Iterable\'>'));
   });
@@ -199,28 +199,28 @@ void main() {
     shouldFail(
         d,
         unorderedMatches([greaterThan(0)]),
-        "Expected: matches [a value greater than <0>] unordered "
-        "Actual: [1, 2] "
-        "Which: has too many elements (2 > 1)");
+        'Expected: matches [a value greater than <0>] unordered '
+        'Actual: [1, 2] '
+        'Which: has too many elements (2 > 1)');
     shouldFail(
         d,
         unorderedMatches([3, 2, 1]),
-        "Expected: matches [<3>, <2>, <1>] unordered "
-        "Actual: [1, 2] "
-        "Which: has too few elements (2 < 3)");
+        'Expected: matches [<3>, <2>, <1>] unordered '
+        'Actual: [1, 2] '
+        'Which: has too few elements (2 < 3)');
     shouldFail(
         d,
         unorderedMatches([3, 1]),
-        "Expected: matches [<3>, <1>] unordered "
-        "Actual: [1, 2] "
-        "Which: has no match for <3> at index 0");
+        'Expected: matches [<3>, <1>] unordered '
+        'Actual: [1, 2] '
+        'Which: has no match for <3> at index 0');
     shouldFail(
         d,
         unorderedMatches([greaterThan(3), greaterThan(0)]),
-        "Expected: matches [a value greater than <3>, a value greater than "
-        "<0>] unordered "
-        "Actual: [1, 2] "
-        "Which: has no match for a value greater than <3> at index 0");
+        'Expected: matches [a value greater than <3>, a value greater than '
+        '<0>] unordered '
+        'Actual: [1, 2] '
+        'Which: has no match for a value greater than <3> at index 0');
     shouldFail('not an iterable', unorderedMatches([greaterThan(1)]),
         endsWith('not an <Instance of \'Iterable\'>'));
   });
@@ -234,22 +234,22 @@ void main() {
     shouldFail(
         d,
         containsAll([1, 2, 3]),
-        "Expected: contains all of [1, 2, 3] "
-        "Actual: [0, 1, 2] "
-        "Which: has no match for <3> at index 2");
+        'Expected: contains all of [1, 2, 3] '
+        'Actual: [0, 1, 2] '
+        'Which: has no match for <3> at index 2');
     shouldFail(
         1,
         containsAll([1]),
-        "Expected: contains all of [1] "
-        "Actual: <1> "
+        'Expected: contains all of [1] '
+        'Actual: <1> '
         "Which: not an <Instance of \'Iterable\'>");
     shouldFail(
         [-1, 2],
         containsAll([greaterThan(0), greaterThan(1)]),
-        "Expected: contains all of [<a value greater than <0>>, "
-        "<a value greater than <1>>] "
-        "Actual: [-1, 2] "
-        "Which: has no match for a value greater than <1> at index 1");
+        'Expected: contains all of [<a value greater than <0>>, '
+        '<a value greater than <1>>] '
+        'Actual: [-1, 2] '
+        'Which: has no match for a value greater than <1> at index 1');
     shouldFail('not an iterable', containsAll([1, 2, 3]),
         endsWith('not an <Instance of \'Iterable\'>'));
   });
@@ -261,30 +261,30 @@ void main() {
     shouldFail(
         d,
         containsAllInOrder([2, 1]),
-        "Expected: contains in order([2, 1]) "
-        "Actual: [0, 1, 0, 2] "
-        "Which: did not find a value matching <1> following expected prior "
-        "values");
+        'Expected: contains in order([2, 1]) '
+        'Actual: [0, 1, 0, 2] '
+        'Which: did not find a value matching <1> following expected prior '
+        'values');
     shouldFail(
         d,
         containsAllInOrder([greaterThan(1), greaterThan(0)]),
-        "Expected: contains in order([<a value greater than <1>>, "
-        "<a value greater than <0>>]) "
-        "Actual: [0, 1, 0, 2] "
-        "Which: did not find a value matching a value greater than <0> "
-        "following expected prior values");
+        'Expected: contains in order([<a value greater than <1>>, '
+        '<a value greater than <0>>]) '
+        'Actual: [0, 1, 0, 2] '
+        'Which: did not find a value matching a value greater than <0> '
+        'following expected prior values');
     shouldFail(
         d,
         containsAllInOrder([1, 2, 3]),
-        "Expected: contains in order([1, 2, 3]) "
-        "Actual: [0, 1, 0, 2] "
-        "Which: did not find a value matching <3> following expected prior "
-        "values");
+        'Expected: contains in order([1, 2, 3]) '
+        'Actual: [0, 1, 0, 2] '
+        'Which: did not find a value matching <3> following expected prior '
+        'values');
     shouldFail(
         1,
         containsAllInOrder([1]),
-        "Expected: contains in order([1]) "
-        "Actual: <1> "
+        'Expected: contains in order([1]) '
+        'Actual: <1> '
         "Which: not an <Instance of \'Iterable\'>");
   });
 
@@ -294,34 +294,34 @@ void main() {
     var e = [1, 4, 9];
     shouldFail(
         'x',
-        pairwiseCompare(e, (int e, int a) => a <= e, "less than or equal"),
-        "Expected: pairwise less than or equal [1, 4, 9] "
+        pairwiseCompare(e, (int e, int a) => a <= e, 'less than or equal'),
+        'Expected: pairwise less than or equal [1, 4, 9] '
             "Actual: 'x' "
             "Which: not an <Instance of \'Iterable\'>");
     shouldFail(
         c,
-        pairwiseCompare(e, (int e, int a) => a <= e, "less than or equal"),
-        "Expected: pairwise less than or equal [1, 4, 9] "
-        "Actual: [1, 2] "
-        "Which: has length 2 instead of 3");
+        pairwiseCompare(e, (int e, int a) => a <= e, 'less than or equal'),
+        'Expected: pairwise less than or equal [1, 4, 9] '
+        'Actual: [1, 2] '
+        'Which: has length 2 instead of 3');
     shouldPass(
-        d, pairwiseCompare(e, (int e, int a) => a <= e, "less than or equal"));
+        d, pairwiseCompare(e, (int e, int a) => a <= e, 'less than or equal'));
     shouldFail(
         d,
-        pairwiseCompare(e, (int e, int a) => a < e, "less than"),
-        "Expected: pairwise less than [1, 4, 9] "
-        "Actual: [1, 2, 3] "
-        "Which: has <1> which is not less than <1> at index 0");
-    shouldPass(d, pairwiseCompare(e, (e, a) => a * a == e, "square root of"));
+        pairwiseCompare(e, (int e, int a) => a < e, 'less than'),
+        'Expected: pairwise less than [1, 4, 9] '
+        'Actual: [1, 2, 3] '
+        'Which: has <1> which is not less than <1> at index 0');
+    shouldPass(d, pairwiseCompare(e, (e, a) => a * a == e, 'square root of'));
     shouldFail(
         d,
-        pairwiseCompare(e, (e, a) => a + a == e, "double"),
-        "Expected: pairwise double [1, 4, 9] "
-        "Actual: [1, 2, 3] "
-        "Which: has <1> which is not double <1> at index 0");
+        pairwiseCompare(e, (e, a) => a + a == e, 'double'),
+        'Expected: pairwise double [1, 4, 9] '
+        'Actual: [1, 2, 3] '
+        'Which: has <1> which is not double <1> at index 0');
     shouldFail(
         'not an iterable',
-        pairwiseCompare(e, (e, a) => a + a == e, "double"),
+        pairwiseCompare(e, (e, a) => a + a == e, 'double'),
         endsWith('not an <Instance of \'Iterable\'>'));
   });
 
@@ -332,8 +332,8 @@ void main() {
     shouldFail(
         e,
         isEmpty,
-        "Expected: empty "
-        "Actual: SimpleIterable:[1]");
+        'Expected: empty '
+        'Actual: SimpleIterable:[1]');
   });
 
   test('isNotEmpty', () {
@@ -343,8 +343,8 @@ void main() {
     shouldFail(
         d,
         isNotEmpty,
-        "Expected: non-empty "
-        "Actual: SimpleIterable:[]");
+        'Expected: non-empty '
+        'Actual: SimpleIterable:[]');
   });
 
   test('contains', () {
@@ -353,7 +353,7 @@ void main() {
     shouldFail(
         d,
         contains(5),
-        "Expected: contains <5> "
-        "Actual: SimpleIterable:[3, 2, 1]");
+        'Expected: contains <5> '
+        'Actual: SimpleIterable:[3, 2, 1]');
   });
 }

--- a/test/numeric_matchers_test.dart
+++ b/test/numeric_matchers_test.dart
@@ -15,15 +15,15 @@ void main() {
     shouldFail(
         1.001,
         closeTo(0, 1),
-        "Expected: a numeric value within <1> of <0> "
-        "Actual: <1.001> "
-        "Which: differs by <1.001>");
+        'Expected: a numeric value within <1> of <0> '
+        'Actual: <1.001> '
+        'Which: differs by <1.001>');
     shouldFail(
         -1.001,
         closeTo(0, 1),
-        "Expected: a numeric value within <1> of <0> "
-        "Actual: <-1.001> "
-        "Which: differs by <1.001>");
+        'Expected: a numeric value within <1> of <0> '
+        'Actual: <-1.001> '
+        'Which: differs by <1.001>');
     shouldFail(
         'not a num', closeTo(0, 1), endsWith('not an <Instance of \'num\'>'));
   });
@@ -32,16 +32,16 @@ void main() {
     shouldFail(
         -1,
         inInclusiveRange(0, 2),
-        "Expected: be in range from 0 (inclusive) to 2 (inclusive) "
-        "Actual: <-1>");
+        'Expected: be in range from 0 (inclusive) to 2 (inclusive) '
+        'Actual: <-1>');
     shouldPass(0, inInclusiveRange(0, 2));
     shouldPass(1, inInclusiveRange(0, 2));
     shouldPass(2, inInclusiveRange(0, 2));
     shouldFail(
         3,
         inInclusiveRange(0, 2),
-        "Expected: be in range from 0 (inclusive) to 2 (inclusive) "
-        "Actual: <3>");
+        'Expected: be in range from 0 (inclusive) to 2 (inclusive) '
+        'Actual: <3>');
     shouldFail('not a num', inInclusiveRange(0, 1),
         endsWith('not an <Instance of \'num\'>'));
   });
@@ -50,14 +50,14 @@ void main() {
     shouldFail(
         0,
         inExclusiveRange(0, 2),
-        "Expected: be in range from 0 (exclusive) to 2 (exclusive) "
-        "Actual: <0>");
+        'Expected: be in range from 0 (exclusive) to 2 (exclusive) '
+        'Actual: <0>');
     shouldPass(1, inExclusiveRange(0, 2));
     shouldFail(
         2,
         inExclusiveRange(0, 2),
-        "Expected: be in range from 0 (exclusive) to 2 (exclusive) "
-        "Actual: <2>");
+        'Expected: be in range from 0 (exclusive) to 2 (exclusive) '
+        'Actual: <2>');
     shouldFail('not a num', inExclusiveRange(0, 1),
         endsWith('not an <Instance of \'num\'>'));
   });
@@ -66,8 +66,8 @@ void main() {
     shouldFail(
         0,
         inOpenClosedRange(0, 2),
-        "Expected: be in range from 0 (exclusive) to 2 (inclusive) "
-        "Actual: <0>");
+        'Expected: be in range from 0 (exclusive) to 2 (inclusive) '
+        'Actual: <0>');
     shouldPass(1, inOpenClosedRange(0, 2));
     shouldPass(2, inOpenClosedRange(0, 2));
     shouldFail('not a num', inOpenClosedRange(0, 1),
@@ -80,8 +80,8 @@ void main() {
     shouldFail(
         2,
         inClosedOpenRange(0, 2),
-        "Expected: be in range from 0 (inclusive) to 2 (exclusive) "
-        "Actual: <2>");
+        'Expected: be in range from 0 (inclusive) to 2 (exclusive) '
+        'Actual: <2>');
     shouldFail('not a num', inClosedOpenRange(0, 1),
         endsWith('not an <Instance of \'num\'>'));
   });
@@ -91,9 +91,9 @@ void main() {
       shouldFail(
           double.nan,
           inExclusiveRange(double.negativeInfinity, double.infinity),
-          "Expected: be in range from "
-          "-Infinity (exclusive) to Infinity (exclusive) "
-          "Actual: <NaN>");
+          'Expected: be in range from '
+          '-Infinity (exclusive) to Infinity (exclusive) '
+          'Actual: <NaN>');
     });
   });
 }

--- a/test/operator_matchers_test.dart
+++ b/test/operator_matchers_test.dart
@@ -11,12 +11,12 @@ void main() {
   test('anyOf', () {
     // with a list
     shouldFail(
-        0, anyOf([equals(1), equals(2)]), "Expected: (<1> or <2>) Actual: <0>");
+        0, anyOf([equals(1), equals(2)]), 'Expected: (<1> or <2>) Actual: <0>');
     shouldPass(1, anyOf([equals(1), equals(2)]));
 
     // with individual items
     shouldFail(
-        0, anyOf(equals(1), equals(2)), "Expected: (<1> or <2>) Actual: <0>");
+        0, anyOf(equals(1), equals(2)), 'Expected: (<1> or <2>) Actual: <0>');
     shouldPass(1, anyOf(equals(1), equals(2)));
   });
 
@@ -26,18 +26,18 @@ void main() {
     shouldFail(
         -1,
         allOf([lessThan(10), greaterThan(0)]),
-        "Expected: (a value less than <10> and a value greater than <0>) "
-        "Actual: <-1> "
-        "Which: is not a value greater than <0>");
+        'Expected: (a value less than <10> and a value greater than <0>) '
+        'Actual: <-1> '
+        'Which: is not a value greater than <0>');
 
     // with individual items
     shouldPass(1, allOf(lessThan(10), greaterThan(0)));
     shouldFail(
         -1,
         allOf(lessThan(10), greaterThan(0)),
-        "Expected: (a value less than <10> and a value greater than <0>) "
-        "Actual: <-1> "
-        "Which: is not a value greater than <0>");
+        'Expected: (a value less than <10> and a value greater than <0>) '
+        'Actual: <-1> '
+        'Which: is not a value greater than <0>');
 
     // with maximum items
     shouldPass(
@@ -48,11 +48,11 @@ void main() {
         4,
         allOf(lessThan(10), lessThan(9), lessThan(8), lessThan(7), lessThan(6),
             lessThan(5), lessThan(4)),
-        "Expected: (a value less than <10> and a value less than <9> and a "
-        "value less than <8> and a value less than <7> and a value less than "
-        "<6> and a value less than <5> and a value less than <4>) "
-        "Actual: <4> "
-        "Which: is not a value less than <4>");
+        'Expected: (a value less than <10> and a value less than <9> and a '
+        'value less than <8> and a value less than <7> and a value less than '
+        '<6> and a value less than <5> and a value less than <4>) '
+        'Actual: <4> '
+        'Which: is not a value less than <4>');
   });
 
   test('If the first argument is a List, the rest must be null', () {

--- a/test/order_matchers_test.dart
+++ b/test/order_matchers_test.dart
@@ -13,9 +13,9 @@ void main() {
     shouldFail(
         9,
         greaterThan(10),
-        "Expected: a value greater than <10> "
-        "Actual: <9> "
-        "Which: is not a value greater than <10>");
+        'Expected: a value greater than <10> '
+        'Actual: <9> '
+        'Which: is not a value greater than <10>');
   });
 
   test('greaterThanOrEqualTo', () {
@@ -23,18 +23,18 @@ void main() {
     shouldFail(
         9,
         greaterThanOrEqualTo(10),
-        "Expected: a value greater than or equal to <10> "
-        "Actual: <9> "
-        "Which: is not a value greater than or equal to <10>");
+        'Expected: a value greater than or equal to <10> '
+        'Actual: <9> '
+        'Which: is not a value greater than or equal to <10>');
   });
 
   test('lessThan', () {
     shouldFail(
         10,
         lessThan(9),
-        "Expected: a value less than <9> "
-        "Actual: <10> "
-        "Which: is not a value less than <9>");
+        'Expected: a value less than <9> '
+        'Actual: <10> '
+        'Which: is not a value less than <9>');
     shouldPass(9, lessThan(10));
   });
 
@@ -43,9 +43,9 @@ void main() {
     shouldFail(
         11,
         lessThanOrEqualTo(10),
-        "Expected: a value less than or equal to <10> "
-        "Actual: <11> "
-        "Which: is not a value less than or equal to <10>");
+        'Expected: a value less than or equal to <10> '
+        'Actual: <11> '
+        'Which: is not a value less than or equal to <10>');
   });
 
   test('isZero', () {
@@ -53,18 +53,18 @@ void main() {
     shouldFail(
         1,
         isZero,
-        "Expected: a value equal to <0> "
-        "Actual: <1> "
-        "Which: is not a value equal to <0>");
+        'Expected: a value equal to <0> '
+        'Actual: <1> '
+        'Which: is not a value equal to <0>');
   });
 
   test('isNonZero', () {
     shouldFail(
         0,
         isNonZero,
-        "Expected: a value not equal to <0> "
-        "Actual: <0> "
-        "Which: is not a value not equal to <0>");
+        'Expected: a value not equal to <0> '
+        'Actual: <0> '
+        'Which: is not a value not equal to <0>');
     shouldPass(1, isNonZero);
   });
 
@@ -72,15 +72,15 @@ void main() {
     shouldFail(
         -1,
         isPositive,
-        "Expected: a positive value "
-        "Actual: <-1> "
-        "Which: is not a positive value");
+        'Expected: a positive value '
+        'Actual: <-1> '
+        'Which: is not a positive value');
     shouldFail(
         0,
         isPositive,
-        "Expected: a positive value "
-        "Actual: <0> "
-        "Which: is not a positive value");
+        'Expected: a positive value '
+        'Actual: <0> '
+        'Which: is not a positive value');
     shouldPass(1, isPositive);
   });
 
@@ -89,9 +89,9 @@ void main() {
     shouldFail(
         0,
         isNegative,
-        "Expected: a negative value "
-        "Actual: <0> "
-        "Which: is not a negative value");
+        'Expected: a negative value '
+        'Actual: <0> '
+        'Which: is not a negative value');
   });
 
   test('isNonPositive', () {
@@ -100,9 +100,9 @@ void main() {
     shouldFail(
         1,
         isNonPositive,
-        "Expected: a non-positive value "
-        "Actual: <1> "
-        "Which: is not a non-positive value");
+        'Expected: a non-positive value '
+        'Actual: <1> '
+        'Which: is not a non-positive value');
   });
 
   test('isNonNegative', () {
@@ -111,9 +111,9 @@ void main() {
     shouldFail(
         -1,
         isNonNegative,
-        "Expected: a non-negative value "
-        "Actual: <-1> "
-        "Which: is not a non-negative value");
+        'Expected: a non-negative value '
+        'Actual: <-1> '
+        'Which: is not a non-negative value');
   });
 
   group('NaN', () {
@@ -121,30 +121,30 @@ void main() {
       shouldFail(
           double.nan,
           greaterThan(10),
-          "Expected: a value greater than <10> "
-          "Actual: <NaN> "
-          "Which: is not a value greater than <10>");
+          'Expected: a value greater than <10> '
+          'Actual: <NaN> '
+          'Which: is not a value greater than <10>');
       shouldFail(
           10,
           greaterThan(double.nan),
-          "Expected: a value greater than <NaN> "
-          "Actual: <10> "
-          "Which: is not a value greater than <NaN>");
+          'Expected: a value greater than <NaN> '
+          'Actual: <10> '
+          'Which: is not a value greater than <NaN>');
     });
 
     test('lessThanOrEqualTo', () {
       shouldFail(
           double.nan,
           lessThanOrEqualTo(10),
-          "Expected: a value less than or equal to <10> "
-          "Actual: <NaN> "
-          "Which: is not a value less than or equal to <10>");
+          'Expected: a value less than or equal to <10> '
+          'Actual: <NaN> '
+          'Which: is not a value less than or equal to <10>');
       shouldFail(
           10,
           lessThanOrEqualTo(double.nan),
-          "Expected: a value less than or equal to <NaN> "
-          "Actual: <10> "
-          "Which: is not a value less than or equal to <NaN>");
+          'Expected: a value less than or equal to <NaN> '
+          'Actual: <10> '
+          'Which: is not a value less than or equal to <NaN>');
     });
   });
 }

--- a/test/pretty_print_test.dart
+++ b/test/pretty_print_test.dart
@@ -14,12 +14,12 @@ class DefaultToString {}
 
 class CustomToString {
   @override
-  String toString() => "string representation";
+  String toString() => 'string representation';
 }
 
 class _PrivateName {
   @override
-  String toString() => "string representation";
+  String toString() => 'string representation';
 }
 
 class _PrivateNameIterable extends IterableMixin {
@@ -63,13 +63,13 @@ void main() {
     test('containing a multiline string', () {
       expect(
           prettyPrint(['foo', 'bar\nbaz\nbip', 'qux']),
-          equals("[\n"
+          equals('[\n'
               "  'foo',\n"
               "  'bar\\n'\n"
               "    'baz\\n'\n"
               "    'bip',\n"
               "  'qux'\n"
-              "]"));
+              ']'));
     });
 
     test('containing a matcher', () {
@@ -79,68 +79,68 @@ void main() {
 
     test("that's under maxLineLength", () {
       expect(prettyPrint([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], maxLineLength: 30),
-          equals("[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]"));
+          equals('[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]'));
     });
 
     test("that's over maxLineLength", () {
       expect(
           prettyPrint([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], maxLineLength: 29),
-          equals("[\n"
-              "  0,\n"
-              "  1,\n"
-              "  2,\n"
-              "  3,\n"
-              "  4,\n"
-              "  5,\n"
-              "  6,\n"
-              "  7,\n"
-              "  8,\n"
-              "  9\n"
-              "]"));
+          equals('[\n'
+              '  0,\n'
+              '  1,\n'
+              '  2,\n'
+              '  3,\n'
+              '  4,\n'
+              '  5,\n'
+              '  6,\n'
+              '  7,\n'
+              '  8,\n'
+              '  9\n'
+              ']'));
     });
 
-    test("factors indentation into maxLineLength", () {
+    test('factors indentation into maxLineLength', () {
       expect(
           prettyPrint([
-            "foo\nbar",
+            'foo\nbar',
             [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
           ], maxLineLength: 30),
-          equals("[\n"
+          equals('[\n'
               "  'foo\\n'\n"
               "    'bar',\n"
-              "  [\n"
-              "    0,\n"
-              "    1,\n"
-              "    2,\n"
-              "    3,\n"
-              "    4,\n"
-              "    5,\n"
-              "    6,\n"
-              "    7,\n"
-              "    8,\n"
-              "    9\n"
-              "  ]\n"
-              "]"));
+              '  [\n'
+              '    0,\n'
+              '    1,\n'
+              '    2,\n'
+              '    3,\n'
+              '    4,\n'
+              '    5,\n'
+              '    6,\n'
+              '    7,\n'
+              '    8,\n'
+              '    9\n'
+              '  ]\n'
+              ']'));
     });
 
     test("that's under maxItems", () {
       expect(prettyPrint([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], maxItems: 10),
-          equals("[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]"));
+          equals('[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]'));
     });
 
     test("that's over maxItems", () {
       expect(prettyPrint([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], maxItems: 9),
-          equals("[0, 1, 2, 3, 4, 5, 6, 7, ...]"));
+          equals('[0, 1, 2, 3, 4, 5, 6, 7, ...]'));
     });
 
     test("that's recursive", () {
       var list = <dynamic>[1, 2, 3];
       list.add(list);
-      expect(prettyPrint(list), equals("[1, 2, 3, (recursive)]"));
+      expect(prettyPrint(list), equals('[1, 2, 3, (recursive)]'));
     });
   });
 
-  group("with a map", () {
+  group('with a map', () {
     test('containing primitive objects', () {
       expect(prettyPrint({'foo': 1, 'bar': true}),
           equals("{'foo': 1, 'bar': true}"));
@@ -149,31 +149,31 @@ void main() {
     test('containing a multiline string key', () {
       expect(
           prettyPrint({'foo\nbar': 1, 'bar': true}),
-          equals("{\n"
+          equals('{\n'
               "  'foo\\n'\n"
               "    'bar': 1,\n"
               "  'bar': true\n"
-              "}"));
+              '}'));
     });
 
     test('containing a multiline string value', () {
       expect(
           prettyPrint({'foo': 'bar\nbaz', 'qux': true}),
-          equals("{\n"
+          equals('{\n'
               "  'foo': 'bar\\n'\n"
               "    'baz',\n"
               "  'qux': true\n"
-              "}"));
+              '}'));
     });
 
     test('containing a multiline string key/value pair', () {
       expect(
           prettyPrint({'foo\nbar': 'baz\nqux'}),
-          equals("{\n"
+          equals('{\n'
               "  'foo\\n'\n"
               "    'bar': 'baz\\n'\n"
               "    'qux'\n"
-              "}"));
+              '}'));
     });
 
     test('containing a matcher key', () {
@@ -194,30 +194,30 @@ void main() {
     test("that's over maxLineLength", () {
       expect(
           prettyPrint({'0': 1, '2': 3, '4': 5, '6': 7}, maxLineLength: 31),
-          equals("{\n"
+          equals('{\n'
               "  '0': 1,\n"
               "  '2': 3,\n"
               "  '4': 5,\n"
               "  '6': 7\n"
-              "}"));
+              '}'));
     });
 
-    test("factors indentation into maxLineLength", () {
+    test('factors indentation into maxLineLength', () {
       expect(
           prettyPrint([
-            "foo\nbar",
+            'foo\nbar',
             {'0': 1, '2': 3, '4': 5, '6': 7}
           ], maxLineLength: 32),
-          equals("[\n"
+          equals('[\n'
               "  'foo\\n'\n"
               "    'bar',\n"
-              "  {\n"
+              '  {\n'
               "    '0': 1,\n"
               "    '2': 3,\n"
               "    '4': 5,\n"
               "    '6': 7\n"
-              "  }\n"
-              "]"));
+              '  }\n'
+              ']'));
     });
 
     test("that's under maxItems", () {
@@ -252,13 +252,13 @@ void main() {
       expect(
           prettyPrint([1, 2, 3, 4].map((n) => n * 2)),
           equals(isDart2
-              ? "MappedListIterable<int, int>:[2, 4, 6, 8]"
-              : "MappedListIterable:[2, 4, 6, 8]"));
+              ? 'MappedListIterable<int, int>:[2, 4, 6, 8]'
+              : 'MappedListIterable:[2, 4, 6, 8]'));
     });
 
     test("that's not a list and has a private name", () {
       expect(prettyPrint(_PrivateNameIterable()),
-          equals("_PrivateNameIterable:[1, 2, 3]"));
+          equals('_PrivateNameIterable:[1, 2, 3]'));
     });
   });
 

--- a/test/string_matchers_test.dart
+++ b/test/string_matchers_test.dart
@@ -13,13 +13,13 @@ void main() {
         contains('Differ at offset 7'));
   });
 
-  test("Retains outer matcher mismatch text", () {
+  test('Retains outer matcher mismatch text', () {
     shouldFail(
         {'word': 'thing'},
         containsPair('word', equals('notthing')),
         allOf([
           contains("contains key 'word' but with value is different"),
-          contains("Differ at offset 0")
+          contains('Differ at offset 0')
         ]));
   });
 
@@ -30,8 +30,8 @@ void main() {
 
   test('isEmpty', () {
     shouldPass('', isEmpty);
-    shouldFail(null, isEmpty, startsWith("Expected: empty  Actual: <null>"));
-    shouldFail(0, isEmpty, startsWith("Expected: empty  Actual: <0>"));
+    shouldFail(null, isEmpty, startsWith('Expected: empty  Actual: <null>'));
+    shouldFail(0, isEmpty, startsWith('Expected: empty  Actual: <0>'));
     shouldFail('a', isEmpty, startsWith("Expected: empty  Actual: 'a'"));
   });
 
@@ -46,8 +46,8 @@ void main() {
   test('isNotEmpty', () {
     shouldFail('', isNotEmpty, startsWith("Expected: non-empty  Actual: ''"));
     shouldFail(
-        null, isNotEmpty, startsWith("Expected: non-empty  Actual: <null>"));
-    shouldFail(0, isNotEmpty, startsWith("Expected: non-empty  Actual: <0>"));
+        null, isNotEmpty, startsWith('Expected: non-empty  Actual: <null>'));
+    shouldFail(0, isNotEmpty, startsWith('Expected: non-empty  Actual: <0>'));
     shouldPass('a', isNotEmpty);
   });
 


### PR DESCRIPTION
- prefer_single_quotes
- prefer_spread_collections
- unused_field
- use_function_type_syntax_for_parameters

Bump min sdk to 2.3.0 to allow for spreads in collection literals.

Drop unused author field from pubspec.