### PR TITLE
Update SDK constraint to require Dart 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: dart
 
 dart:
-  - 2.3.0
+  - 2.4.0
   - dev
 
 dart_task:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.12.7-dev
+
+- Update minimum Dart SDK to `2.4.0`.
+
 ## 0.12.6
 
 - Update minimum Dart SDK to `2.2.0`.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ description: >-
 homepage: https://github.com/dart-lang/matcher
 
 environment:
-  sdk: '>=2.3.0 <3.0.0'
+  sdk: '>=2.4.0 <3.0.0'
 
 dependencies:
   stack_trace: ^1.2.0
@@ -17,4 +17,6 @@ dev_dependencies:
   test: '>=0.12.0 <2.0.0'
 
 dependency_overrides:
-  test: ^1.3.0
+  test: ^1.12.0
+  test_api: ^0.2.14
+  test_core: ^0.3.0


### PR DESCRIPTION
Update dependency overrides to get the latest version of test(_*) pkgs