### PR TITLE
Deprecate isCastError

### DIFF
--- a/lib/src/error_matchers.dart
+++ b/lib/src/error_matchers.dart
@@ -8,6 +8,9 @@ import 'type_matcher.dart';
 const isArgumentError = TypeMatcher<ArgumentError>();
 
 /// A matcher for [CastError].
+@Deprecated('CastError has been deprecated in favor of TypeError. '
+    'Use `isA<TypeError>()` or, if you need compatibility with older SDKs, '
+    'use `isA<CastError>()` and ignore the deprecation.')
 const isCastError = TypeMatcher<CastError>();
 
 /// A matcher for [ConcurrentModificationError].

--- a/test/type_matcher_test.dart
+++ b/test/type_matcher_test.dart
@@ -11,6 +11,7 @@ void main() {
   _test(isMap, {}, name: 'Map');
   _test(isList, [], name: 'List');
   _test(isArgumentError, ArgumentError());
+  // ignore: deprecated_member_use, deprecated_member_use_from_same_package
   _test(isCastError, CastError());
   _test<Exception>(isException, const FormatException());
   _test(isFormatException, const FormatException());


### PR DESCRIPTION
For consistency with the SDK, and in anticipation of all `is*Error`
matchers being deprecated in some future release, eagerly deprecate
`isCastError`.