### PR TITLE
Rework _DeepMatcher so that it can display details of match failures.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.12.9
+
+- Improve mismatch descriptions for deep matches.  Previously, if the user tried
+  to do a deep match where the expectation included a complex matcher (such as a
+  "having" matcher), the failure message would just say "failed to match ...";
+  it wouldn't call on the expectation's matcher to explain why the match failed.
+
 ## 0.12.8
 
 - Add a mismatch description to `TypeMatcher`.

--- a/lib/src/equals_matcher.dart
+++ b/lib/src/equals_matcher.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'description.dart';
 import 'feature_matcher.dart';
 import 'interfaces.dart';
 import 'util.dart';
@@ -20,8 +19,7 @@ Matcher equals(expected, [int limit = 100]) => expected is String
     ? _StringEqualsMatcher(expected)
     : _DeepMatcher(expected, limit);
 
-typedef _RecursiveMatcher = List<String> Function(
-    dynamic, dynamic, String, int);
+typedef _RecursiveMatcher = _Mismatch Function(dynamic, dynamic, String, int);
 
 /// A special equality matcher for strings.
 class _StringEqualsMatcher extends FeatureMatcher<String> {
@@ -104,8 +102,7 @@ class _DeepMatcher extends Matcher {
 
   _DeepMatcher(this._expected, [int limit = 1000]) : _limit = limit;
 
-  // Returns a pair (reason, location)
-  List<String> _compareIterables(Iterable expected, Object actual,
+  _Mismatch _compareIterables(Iterable expected, Object actual,
       _RecursiveMatcher matcher, int depth, String location) {
     if (actual is Iterable) {
       var expectedIterator = expected.iterator;
@@ -120,8 +117,12 @@ class _DeepMatcher extends Matcher {
 
         // Fail if their lengths are different.
         var newLocation = '$location[$index]';
-        if (!expectedNext) return ['longer than expected', newLocation];
-        if (!actualNext) return ['shorter than expected', newLocation];
+        if (!expectedNext) {
+          return _Mismatch.simple(newLocation, actual, 'longer than expected');
+        }
+        if (!actualNext) {
+          return _Mismatch.simple(newLocation, actual, 'shorter than expected');
+        }
 
         // Match the elements.
         var rp = matcher(expectedIterator.current, actualIterator.current,
@@ -129,55 +130,71 @@ class _DeepMatcher extends Matcher {
         if (rp != null) return rp;
       }
     } else {
-      return ['is not Iterable', location];
+      return _Mismatch.simple(location, actual, 'is not Iterable');
     }
   }
 
-  List<String> _compareSets(Set expected, Object actual,
-      _RecursiveMatcher matcher, int depth, String location) {
+  _Mismatch _compareSets(Set expected, Object actual, _RecursiveMatcher matcher,
+      int depth, String location) {
     if (actual is Iterable) {
       var other = actual.toSet();
 
       for (var expectedElement in expected) {
         if (other.every((actualElement) =>
             matcher(expectedElement, actualElement, location, depth) != null)) {
-          return ['does not contain $expectedElement', location];
+          return _Mismatch(
+              location,
+              actual,
+              (description, verbose) => description
+                  .add('does not contain ')
+                  .addDescriptionOf(expectedElement));
         }
       }
 
       if (other.length > expected.length) {
-        return ['larger than expected', location];
+        return _Mismatch.simple(location, actual, 'larger than expected');
       } else if (other.length < expected.length) {
-        return ['smaller than expected', location];
+        return _Mismatch.simple(location, actual, 'smaller than expected');
       } else {
         return null;
       }
     } else {
-      return ['is not Iterable', location];
+      return _Mismatch.simple(location, actual, 'is not Iterable');
     }
   }
 
-  List<String> _recursiveMatch(
+  _Mismatch _recursiveMatch(
       Object expected, Object actual, String location, int depth) {
     // If the expected value is a matcher, try to match it.
     if (expected is Matcher) {
       var matchState = {};
       if (expected.matches(actual, matchState)) return null;
-
-      var description = StringDescription();
-      expected.describe(description);
-      return ['does not match $description', location];
+      return _Mismatch(location, actual, (description, verbose) {
+        var oldLength = description.length;
+        expected.describeMismatch(actual, description, matchState, verbose);
+        if (depth > 0 && description.length == oldLength) {
+          description.add('does not match ');
+          expected.describe(description);
+        }
+      });
     } else {
       // Otherwise, test for equality.
       try {
         if (expected == actual) return null;
       } catch (e) {
         // TODO(gram): Add a test for this case.
-        return ['== threw "$e"', location];
+        return _Mismatch(
+            location,
+            actual,
+            (description, verbose) =>
+                description.add('== threw ').addDescriptionOf(e));
       }
     }
 
-    if (depth > _limit) return ['recursion depth limit exceeded', location];
+    if (depth > _limit) {
+      return _Mismatch.simple(
+          location, actual, 'recursion depth limit exceeded');
+    }
 
     // If _limit is 1 we can only recurse one level into object.
     if (depth == 0 || _limit > 1) {
@@ -188,19 +205,31 @@ class _DeepMatcher extends Matcher {
         return _compareIterables(
             expected, actual, _recursiveMatch, depth + 1, location);
       } else if (expected is Map) {
-        if (actual is! Map) return ['expected a map', location];
+        if (actual is! Map) {
+          return _Mismatch.simple(location, actual, 'expected a map');
+        }
         var map = actual as Map;
         var err =
             (expected.length == map.length) ? '' : 'has different length and ';
         for (var key in expected.keys) {
           if (!map.containsKey(key)) {
-            return ["${err}is missing map key '$key'", location];
+            return _Mismatch(
+                location,
+                actual,
+                (description, verbose) => description
+                    .add('${err}is missing map key ')
+                    .addDescriptionOf(key));
           }
         }
 
         for (var key in map.keys) {
           if (!expected.containsKey(key)) {
-            return ["${err}has extra map key '$key'", location];
+            return _Mismatch(
+                location,
+                actual,
+                (description, verbose) => description
+                    .add('${err}has extra map key ')
+                    .addDescriptionOf(key));
           }
         }
 
@@ -214,44 +243,24 @@ class _DeepMatcher extends Matcher {
       }
     }
 
-    var description = StringDescription();
-
     // If we have recursed, show the expected value too; if not, expect() will
     // show it for us.
     if (depth > 0) {
-      description
-          .add('was ')
-          .addDescriptionOf(actual)
-          .add(' instead of ')
-          .addDescriptionOf(expected);
-      return [description.toString(), location];
-    }
-
-    // We're not adding any value to the actual value.
-    return ['', location];
-  }
-
-  String _match(expected, actual, Map matchState) {
-    var rp = _recursiveMatch(expected, actual, '', 0);
-    if (rp == null) return null;
-    String reason;
-    if (rp[0].isNotEmpty) {
-      if (rp[1].isNotEmpty) {
-        reason = '${rp[0]} at location ${rp[1]}';
-      } else {
-        reason = rp[0];
-      }
+      return _Mismatch(location, actual,
+          (description, verbose) => description.addDescriptionOf(expected),
+          instead: true);
     } else {
-      reason = '';
+      return _Mismatch(location, actual, null);
     }
-    // Cache the failure reason in the matchState.
-    addStateInfo(matchState, {'reason': reason});
-    return reason;
   }
 
   @override
-  bool matches(item, Map matchState) =>
-      _match(_expected, item, matchState) == null;
+  bool matches(Object actual, Map matchState) {
+    var mismatch = _recursiveMatch(_expected, actual, '', 0);
+    if (mismatch == null) return true;
+    addStateInfo(matchState, {'mismatch': mismatch});
+    return false;
+  }
 
   @override
   Description describe(Description description) =>
@@ -260,16 +269,48 @@ class _DeepMatcher extends Matcher {
   @override
   Description describeMismatch(
       item, Description mismatchDescription, Map matchState, bool verbose) {
-    var reason = matchState['reason'] as String ?? '';
-    // If we didn't get a good reason, that would normally be a
-    // simple 'is <value>' message. We only add that if the mismatch
-    // description is non empty (so we are supplementing the mismatch
-    // description).
-    if (reason.isEmpty && mismatchDescription.length > 0) {
-      mismatchDescription.add('is ').addDescriptionOf(item);
+    var mismatch = matchState['mismatch'] as _Mismatch;
+    if (mismatch.location.isNotEmpty) {
+      mismatchDescription
+          .add('at location ')
+          .add(mismatch.location)
+          .add(' is ')
+          .addDescriptionOf(mismatch.actual);
+      if (mismatch.describeProblem != null) {
+        mismatchDescription
+            .add(' ${mismatch.instead ? 'instead of ' : 'which'} ');
+        mismatch.describeProblem(mismatchDescription, verbose);
+      }
     } else {
-      mismatchDescription.add(reason);
+      // If we didn't get a good reason, that would normally be a
+      // simple 'is <value>' message. We only add that if the mismatch
+      // description is non empty (so we are supplementing the mismatch
+      // description).
+      if (mismatch.describeProblem == null) {
+        if (mismatchDescription.length > 0) {
+          mismatchDescription.add('is ').addDescriptionOf(item);
+        }
+      } else {
+        mismatch.describeProblem(mismatchDescription, verbose);
+      }
     }
     return mismatchDescription;
   }
+}
+
+class _Mismatch {
+  final String location;
+
+  final Object actual;
+
+  final void Function(Description description, bool verbose) describeProblem;
+
+  final bool instead;
+
+  _Mismatch(this.location, this.actual, this.describeProblem,
+      {this.instead = false});
+
+  _Mismatch.simple(this.location, this.actual, String problem,
+      {this.instead = false})
+      : describeProblem = ((description, verbose) => description.add(problem));
 }

--- a/lib/src/equals_matcher.dart
+++ b/lib/src/equals_matcher.dart
@@ -278,7 +278,7 @@ class _DeepMatcher extends Matcher {
           .addDescriptionOf(mismatch.actual);
       if (mismatch.describeProblem != null) {
         mismatchDescription
-            .add(' ${mismatch.instead ? 'instead of ' : 'which'} ');
+            .add(' ${mismatch.instead ? 'instead of' : 'which'} ');
         mismatch.describeProblem(mismatchDescription, verbose);
       }
     } else {

--- a/lib/src/equals_matcher.dart
+++ b/lib/src/equals_matcher.dart
@@ -307,7 +307,7 @@ class _Mismatch {
   final Object actual;
 
   /// Callback that can create a detailed description of the problem.
-  final void Function(Description description, bool verbose) describeProblem;
+  final void Function(Description, bool verbose) describeProblem;
 
   /// If `true`, [describeProblem] describes the expected value, so when the
   /// final mismatch description is pieced together, it will be preceded by

--- a/lib/src/equals_matcher.dart
+++ b/lib/src/equals_matcher.dart
@@ -299,12 +299,22 @@ class _DeepMatcher extends Matcher {
 }
 
 class _Mismatch {
+  /// A human-readable description of the location within the collection where
+  /// the mismatch occurred.
   final String location;
 
+  /// The actual value found at [location].
   final Object actual;
 
+  /// Callback that can create a detailed description of the problem.
   final void Function(Description description, bool verbose) describeProblem;
 
+  /// If `true`, [describeProblem] describes the expected value, so when the
+  /// final mismatch description is pieced together, it will be preceded by
+  /// `instead of` (e.g. `at location [2] is <3> instead of <4>`).  If `false`,
+  /// [describeProblem] is a problem description from a sub-matcher, so when the
+  /// final mismatch description is pieced together, it will be preceded by
+  /// `which` (e.g. `at location [2] is <foo> which has length of 3`).
   final bool instead;
 
   _Mismatch(this.location, this.actual, this.describeProblem,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: matcher
-version: 0.12.8
+version: 0.12.9
 
 description: >-
   Support for specifying test expectations via an extensible Matcher class.

--- a/test/core_matchers_test.dart
+++ b/test/core_matchers_test.dart
@@ -77,7 +77,7 @@ void main() {
         equals(set1),
         matches(r'Expected: .*:\[1, 2, 3, 4, 5, 6, 7, 8, 9, 10\]'
             r'  Actual: \[1, 2, 3, 4, 5, 6, 7, 8, 9\]'
-            r'   Which: does not contain 10'));
+            r'   Which: does not contain <10>'));
     shouldFail(
         [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
         equals(set1),
@@ -152,7 +152,7 @@ void main() {
         equals([5.1]),
         'Expected: [5.1] '
         "Actual: ['error'] "
-        "Which: was 'error' instead of <5.1> at location [0]");
+        "Which: at location [0] is 'error' instead of <5.1>");
   });
 
   test('doubly-nested type mismatch', () {
@@ -165,7 +165,7 @@ void main() {
         ]),
         'Expected: [[5.1]] '
         "Actual: [['error']] "
-        "Which: was 'error' instead of <5.1> at location [0][0]");
+        "Which: at location [0][0] is 'error' instead of <5.1>");
   });
 
   test('doubly nested inequality', () {
@@ -183,7 +183,7 @@ void main() {
     ];
     var reason1 = "Expected: [['foo', 'bar'], ['foo'], 4, []] "
         "Actual: [['foo', 'bar'], ['foo'], 3, []] "
-        'Which: was <3> instead of <4> at location [2]';
+        'Which: at location [2] is <3> instead of <4>';
 
     var actual2 = [
       ['foo', 'barry'],
@@ -199,7 +199,7 @@ void main() {
     ];
     var reason2 = "Expected: [['foo', 'bar'], ['foo'], 4, []] "
         "Actual: [['foo', 'barry'], ['foo'], 4, []] "
-        "Which: was 'barry' instead of 'bar' at location [0][1]";
+        "Which: at location [0][1] is 'barry' instead of 'bar'";
 
     var actual3 = [
       ['foo', 'bar'],
@@ -215,7 +215,7 @@ void main() {
     ];
     var reason3 = "Expected: [['foo', 'bar'], ['foo'], 4, {'foo': 'barry'}] "
         "Actual: [['foo', 'bar'], ['foo'], 4, {'foo': 'bar'}] "
-        "Which: was 'bar' instead of 'barry' at location [3]['foo']";
+        "Which: at location [3]['foo'] is 'bar' instead of 'barry'";
 
     shouldFail(actual1, equals(expected1), reason1);
     shouldFail(actual2, equals(expected2), reason2);

--- a/test/having_test.dart
+++ b/test/having_test.dart
@@ -49,9 +49,9 @@ void main() {
         "Expected: [ <<Instance of 'RangeError'> with "
         "`message`: contains 'details' and `start`: null and `end`: null> ] "
         'Actual: [RangeError:RangeError: '
-        'Invalid value: Not in inclusive range 1..10: -1] '
+        'Invalid value: Not in range 1..10, inclusive: -1] '
         'Which: at location [0] is RangeError:<RangeError: '
-        'Invalid value: Not in inclusive range 1..10: -1> '
+        'Invalid value: Not in range 1..10, inclusive: -1> '
         "which has `message` with value 'Invalid value'");
   });
 

--- a/test/having_test.dart
+++ b/test/having_test.dart
@@ -42,6 +42,19 @@ void main() {
             .having((e) => e.end, 'end', lessThanOrEqualTo(20))));
   });
 
+  test('having inside deep matcher', () {
+    shouldFail(
+        [RangeError.range(-1, 1, 10)],
+        equals([_rangeMatcher]),
+        "Expected: [ <<Instance of 'RangeError'> with "
+        "`message`: contains 'details' and `start`: null and `end`: null> ] "
+        'Actual: [RangeError:RangeError: '
+        'Invalid value: Not in range 1..10, inclusive: -1] '
+        'Which: at location [0] is RangeError:<RangeError: '
+        'Invalid value: Not in range 1..10, inclusive: -1> '
+        "which has `message` with value 'Invalid value'");
+  });
+
   group('CustomMater copy', () {
     test('Feature Matcher', () {
       var w = Widget();

--- a/test/having_test.dart
+++ b/test/having_test.dart
@@ -49,9 +49,9 @@ void main() {
         "Expected: [ <<Instance of 'RangeError'> with "
         "`message`: contains 'details' and `start`: null and `end`: null> ] "
         'Actual: [RangeError:RangeError: '
-        'Invalid value: Not in range 1..10, inclusive: -1] '
+        'Invalid value: Not in inclusive range 1..10: -1] '
         'Which: at location [0] is RangeError:<RangeError: '
-        'Invalid value: Not in range 1..10, inclusive: -1> '
+        'Invalid value: Not in inclusive range 1..10: -1> '
         "which has `message` with value 'Invalid value'");
   });
 

--- a/test/having_test.dart
+++ b/test/having_test.dart
@@ -46,22 +46,24 @@ void main() {
     shouldFail(
         [RangeError.range(-1, 1, 10)],
         equals([_rangeMatcher]),
-        anyOf([equalsIgnoringWhitespace(
-        "Expected: [ <<Instance of 'RangeError'> with "
-        "`message`: contains 'details' and `start`: null and `end`: null> ] "
-        'Actual: [RangeError:RangeError: '
-        'Invalid value: Not in inclusive range 1..10: -1] '
-        'Which: at location [0] is RangeError:<RangeError: '
-        'Invalid value: Not in inclusive range 1..10: -1> '
-        "which has `message` with value 'Invalid value'"),
-      equalsIgnoringWhitespace( // Older SDKs
-        "Expected: [ <<Instance of 'RangeError'> with "
-        "`message`: contains 'details' and `start`: null and `end`: null> ] "
-        'Actual: [RangeError:RangeError: '
-        'Invalid value: Not in range 1..10, inclusive: -1] '
-        'Which: at location [0] is RangeError:<RangeError: '
-        'Invalid value: Not in range 1..10, inclusive: -1> '
-        "which has `message` with value 'Invalid value'")]));
+        anyOf([
+          equalsIgnoringWhitespace(
+              "Expected: [ <<Instance of 'RangeError'> with "
+              "`message`: contains 'details' and `start`: null and `end`: null> ] "
+              'Actual: [RangeError:RangeError: '
+              'Invalid value: Not in inclusive range 1..10: -1] '
+              'Which: at location [0] is RangeError:<RangeError: '
+              'Invalid value: Not in inclusive range 1..10: -1> '
+              "which has `message` with value 'Invalid value'"),
+          equalsIgnoringWhitespace(// Older SDKs
+              "Expected: [ <<Instance of 'RangeError'> with "
+              "`message`: contains 'details' and `start`: null and `end`: null> ] "
+              'Actual: [RangeError:RangeError: '
+              'Invalid value: Not in range 1..10, inclusive: -1] '
+              'Which: at location [0] is RangeError:<RangeError: '
+              'Invalid value: Not in range 1..10, inclusive: -1> '
+              "which has `message` with value 'Invalid value'")
+        ]));
   });
 
   group('CustomMatcher copy', () {

--- a/test/having_test.dart
+++ b/test/having_test.dart
@@ -46,13 +46,22 @@ void main() {
     shouldFail(
         [RangeError.range(-1, 1, 10)],
         equals([_rangeMatcher]),
+        anyOf([equalsIgnoringWhitespace(
+        "Expected: [ <<Instance of 'RangeError'> with "
+        "`message`: contains 'details' and `start`: null and `end`: null> ] "
+        'Actual: [RangeError:RangeError: '
+        'Invalid value: Not in inclusive range 1..10: -1] '
+        'Which: at location [0] is RangeError:<RangeError: '
+        'Invalid value: Not in inclusive range 1..10: -1> '
+        "which has `message` with value 'Invalid value'"),
+      equalsIgnoringWhitespace( // Older SDKs
         "Expected: [ <<Instance of 'RangeError'> with "
         "`message`: contains 'details' and `start`: null and `end`: null> ] "
         'Actual: [RangeError:RangeError: '
         'Invalid value: Not in range 1..10, inclusive: -1] '
         'Which: at location [0] is RangeError:<RangeError: '
         'Invalid value: Not in range 1..10, inclusive: -1> '
-        "which has `message` with value 'Invalid value'");
+        "which has `message` with value 'Invalid value'")]));
   });
 
   group('CustomMatcher copy', () {

--- a/test/iterable_matchers_test.dart
+++ b/test/iterable_matchers_test.dart
@@ -39,7 +39,8 @@ void main() {
         equals(['foo', endsWith('ba')]),
         "Expected: ['foo', <a string ending with 'ba'>] "
         "Actual: ['foo', 'bar'] "
-        "Which: does not match a string ending with 'ba' at location [1]");
+        "Which: at location [1] is 'bar' which "
+        "does not match a string ending with 'ba'");
   });
 
   test('isIn', () {
@@ -140,7 +141,7 @@ void main() {
         orderedEquals([2, 1]),
         'Expected: equals [2, 1] ordered '
         'Actual: [1, 2] '
-        'Which: was <1> instead of <2> at location [0]');
+        'Which: at location [0] is <1> instead of <2>');
     shouldFail('not an iterable', orderedEquals([1]),
         endsWith('not an <Instance of \'Iterable\'>'));
   });


### PR DESCRIPTION
Previously, if the user tried to do a deep match where the expectation
included a complex matcher (such as a "having" matcher), the failure
message would just say "failed to match ..."; it wouldn't call on the
expectation's matcher to explain why the match failed.

`_DeepMatcher` now stores a `_Mismatch` object in the matchState
map (under the key `mismatch`) recording in detail the location
of the mismatch, the actual and expected values, and if
necessary, a callback that describes the problem in more detail.
This replaces the old `reason` object, which was a String.  Using
a `_Mismatch` object allows us to pass the `verbose` flag through
when calling on the inner expectation's matcher to explain why
the match failed.  It also avoids unnecessary string operations
if no description is needed.