### PR TITLE
Make tests tolerate the new RangeError message

### DIFF
--- a/test/having_test.dart
+++ b/test/having_test.dart
@@ -14,17 +14,17 @@ void main() {
 
   test('failure', () {
     shouldFail(
-        RangeError.range(-1, 1, 10),
-        _rangeMatcher,
-        "Expected: <Instance of 'RangeError'> with "
-        "`message`: contains 'details' and `start`: null and `end`: null "
-        'Actual: RangeError:<RangeError: '
-        'Invalid value: Not in range 1..10, inclusive: -1> '
-        "Which: has `message` with value 'Invalid value'");
+      RangeError.range(-1, 1, 10),
+      _rangeMatcher,
+      _matchesIgnoringWhitespace(r"^Expected: <Instance of 'RangeError'> with "
+          r"`message`: contains 'details' and `start`: null and `end`: null "
+          r'Actual: RangeError:<RangeError: Invalid value: [^>]+> '
+          r"Which: has `message` with value 'Invalid value'$"),
+    );
   });
 
   // This code is used in the [TypeMatcher] doc comments.
-  test('integaration and example', () {
+  test('integration and example', () {
     void shouldThrowRangeError(int value) {
       throw RangeError.range(value, 10, 20);
     }
@@ -42,7 +42,7 @@ void main() {
             .having((e) => e.end, 'end', lessThanOrEqualTo(20))));
   });
 
-  group('CustomMater copy', () {
+  group('CustomMatcher copy', () {
     test('Feature Matcher', () {
       var w = Widget();
       w.price = 10;
@@ -89,3 +89,11 @@ Matcher _hasPrice(matcher) =>
 
 Matcher _badCustomMatcher() => const TypeMatcher<Widget>()
     .having((e) => throw Exception('bang'), 'feature', {1: 'a'});
+
+/// Similar to [equalsIgnoringWhitespace] but matches against a regular
+/// expression.
+Matcher _matchesIgnoringWhitespace(String reString) {
+  final re = RegExp(collapseWhitespace(reString));
+  return predicate(
+      (actualString) => re.hasMatch(collapseWhitespace(actualString)));
+}

--- a/test/having_test.dart
+++ b/test/having_test.dart
@@ -14,12 +14,12 @@ void main() {
 
   test('failure', () {
     shouldFail(
-      RangeError.range(-1, 1, 10),
+      CustomRangeError.range(-1, 1, 10),
       _rangeMatcher,
-      _matchesIgnoringWhitespace(r"^Expected: <Instance of 'RangeError'> with "
-          r"`message`: contains 'details' and `start`: null and `end`: null "
-          r'Actual: RangeError:<RangeError: Invalid value: [^>]+> '
-          r"Which: has `message` with value 'Invalid value'$"),
+      "Expected: <Instance of 'RangeError'> with "
+      "`message`: contains 'details' and `start`: null and `end`: null "
+      'Actual: CustomRangeError:<RangeError: Invalid value: details> '
+      "Which: has `message` with value 'Invalid value'",
     );
   });
 
@@ -90,10 +90,10 @@ Matcher _hasPrice(matcher) =>
 Matcher _badCustomMatcher() => const TypeMatcher<Widget>()
     .having((e) => throw Exception('bang'), 'feature', {1: 'a'});
 
-/// Similar to [equalsIgnoringWhitespace] but matches against a regular
-/// expression.
-Matcher _matchesIgnoringWhitespace(String reString) {
-  final re = RegExp(collapseWhitespace(reString));
-  return predicate(
-      (actualString) => re.hasMatch(collapseWhitespace(actualString)));
+class CustomRangeError extends RangeError {
+  CustomRangeError.range(num invalidValue, int minValue, int maxValue)
+      : super.range(invalidValue, minValue, maxValue);
+
+  @override
+  String toString() => 'RangeError: Invalid value: details';
 }


### PR DESCRIPTION
Background: https://dart-review.googlesource.com/c/sdk/+/146024

The above change breaks package:matcher tests.  Adjust the failure
test to stop caring about an exact error message.

I also considered a much simpler change to make the test check for
both old and new versions of the RangeError message, but:

* If the RangeError message changes again, I'd prefer to avoid
  dealing with this again.

* From a code-coverage standpoint, it's harder to verify that
  multiple versions of the message are correct.