### PR TITLE
Implement describeMismatch for TypeMatcher.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.12.8
+
+- Add a mismatch description to `TypeMatcher`.
+
 ## 0.12.7
 
 - Deprecate the `mirror_matchers.dart` library.

--- a/lib/src/type_matcher.dart
+++ b/lib/src/type_matcher.dart
@@ -90,6 +90,13 @@ class TypeMatcher<T> extends Matcher {
   }
 
   @override
+  Description describeMismatch(
+      item, Description mismatchDescription, Map matchState, bool verbose) {
+    var name = _name ?? _stripDynamic(T);
+    return mismatchDescription.add("is not an instance of '$name'");
+  }
+
+  @override
   bool matches(Object item, Map matchState) => item is T;
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: matcher
-version: 0.12.7
+version: 0.12.8
 
 description: >-
   Support for specifying test expectations via an extensible Matcher class.

--- a/test/type_matcher_test.dart
+++ b/test/type_matcher_test.dart
@@ -46,7 +46,8 @@ void _test<T>(Matcher typeMatcher, T matchingInstance, {String name}) {
       shouldFail(
         const _TestType(),
         typeMatcher,
-        "Expected: <Instance of '$name'> Actual: <Instance of '_TestType'>",
+        "Expected: <Instance of '$name'> Actual: <Instance of '_TestType'>"
+        " Which: is not an instance of '$name'",
       );
     });
   });


### PR DESCRIPTION
This allows testing utilities that operate on matchers to provide
descriptive errors when TypeMatcher does not match.

Fixes #145 