### PR TITLE
Update to latest test_* deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: dart
 
 dart:
-  - 2.4.0
+  - 2.7.0
   - dev
 
 dart_task:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ description: >-
 homepage: https://github.com/dart-lang/matcher
 
 environment:
-  sdk: '>=2.4.0 <3.0.0'
+  sdk: '>=2.7.0 <3.0.0'
 
 dependencies:
   stack_trace: ^1.2.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,9 +14,11 @@ dependencies:
 
 dev_dependencies:
   pedantic: ^1.4.0
-  test: '>=0.12.0 <2.0.0'
+  test: any
+  test_api: any
+  test_core: any
 
 dependency_overrides:
-  test: ^1.12.0
-  test_api: ^0.2.14
-  test_core: ^0.3.0
+  test: ^1.15.0
+  test_api: ^0.2.17
+  test_core: ^0.3.10


### PR DESCRIPTION
Add `test_api` and `test_core` to `dev_dependencies` in addition to
`dependency_overrides`. This prevents a warning on publish about
overriding non-dev dependencies.

Use `any` constraints` for the `dev_dependencies` since they are already
constrained correctly by `dependency_overrides`.