### PR TITLE
Allow wrapping predicates which take dynamic

### DIFF
--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -39,7 +39,7 @@ void addStateInfo(Map matchState, Map values) {
 Matcher wrapMatcher(x) {
   if (x is Matcher) {
     return x;
-  } else if (x is _Predicate<Object>) {
+  } else if (x is _Predicate<Object?>) {
     // x is already a predicate that can handle anything
     return predicate(x);
   } else if (x is _Predicate<Null>) {

--- a/test/core_matchers_test.dart
+++ b/test/core_matchers_test.dart
@@ -237,4 +237,11 @@ void main() {
       }
     });
   });
+
+  group('wrapMatcher', () {
+    test('wraps a predicate which allows a nullable argument', () {
+      final matcher = wrapMatcher((_) => true);
+      shouldPass(null, matcher);
+    });
+  });
 }


### PR DESCRIPTION
The check against `_Predicate<Object>` was intended to be a top type,
but the migration didn't add a `?` so the static type at the call to
`predicate(x)` was `predicate<Object>(x)`. The predicate matcher first
does a type check against it's `T` when matching values, and `null is
Object` returns `false` in an opt-in library. The effect is that a
`Function(dynamic)` gets unnecessarily limited to a `Function(Object)`
and the type check is done artificially by the matcher instead of by the
function itself.

Check against `Object?` instead to make it a null safe top type. Add a
regression test that fails before the fix is applied.