### PR TITLE
Drop Dart 1 test code

### DIFF
--- a/test/core_matchers_test.dart
+++ b/test/core_matchers_test.dart
@@ -228,13 +228,8 @@ void main() {
           'Expected: an instance of String Actual: <0>');
       shouldPass('cow', predicate((x) => x is String, 'an instance of String'));
 
-      if (isDart2) {
-        // With Dart2 semantics, predicate picks up a type argument of `bool`
-        // and we get nice type checking.
-        // Without Dart2 semantics a gnarly type error is thrown.
-        shouldFail(0, predicate((bool x) => x, 'bool value is true'),
-            endsWith("not an <Instance of \'bool\'>"));
-      }
+      shouldFail(0, predicate((bool x) => x, 'bool value is true'),
+          endsWith("not an <Instance of \'bool\'>"));
     });
   });
 

--- a/test/pretty_print_test.dart
+++ b/test/pretty_print_test.dart
@@ -8,8 +8,6 @@ import 'package:matcher/matcher.dart';
 import 'package:matcher/src/pretty_print.dart';
 import 'package:test/test.dart' show group, test, expect;
 
-import 'test_utils.dart';
-
 class DefaultToString {}
 
 class CustomToString {
@@ -249,11 +247,8 @@ void main() {
 
   group('with an iterable', () {
     test("that's not a list", () {
-      expect(
-          prettyPrint([1, 2, 3, 4].map((n) => n * 2)),
-          equals(isDart2
-              ? 'MappedListIterable<int, int>:[2, 4, 6, 8]'
-              : 'MappedListIterable:[2, 4, 6, 8]'));
+      expect(prettyPrint([1, 2, 3, 4].map((n) => n * 2)),
+          equals('MappedListIterable<int, int>:[2, 4, 6, 8]'));
     });
 
     test("that's not a list and has a private name", () {

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -4,11 +4,6 @@
 
 import 'package:test/test.dart';
 
-final bool isDart2 = () {
-  Type checkType<T>() => T;
-  return checkType<String>() == String;
-}();
-
 void shouldFail(value, Matcher matcher, expected) {
   var failed = false;
   try {


### PR DESCRIPTION
These tests have not been run with a Dart 1 SDK for a long time, there
is no need to have conditional gates around legacy behavior.