### PR TITLE
Fix check for predicate with typed argument

### DIFF
--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -42,7 +42,7 @@ Matcher wrapMatcher(x) {
   } else if (x is _Predicate<Object?>) {
     // x is already a predicate that can handle anything
     return predicate(x);
-  } else if (x is _Predicate<Null>) {
+  } else if (x is _Predicate<Never>) {
     // x is a unary predicate, but expects a specific type
     // so wrap it.
     // ignore: unnecessary_lambdas

--- a/test/core_matchers_test.dart
+++ b/test/core_matchers_test.dart
@@ -243,5 +243,10 @@ void main() {
       final matcher = wrapMatcher((_) => true);
       shouldPass(null, matcher);
     });
+
+    test('wraps a predicate which has a typed argument check', () {
+      final matcher = wrapMatcher((int _) => true);
+      shouldPass(1, matcher);
+    });
   });
 }


### PR DESCRIPTION
In legacy Dart `Null` is a bottom type, so checking against
`Function(Null)` is an arity check. In null safe Dart the only bottom
type is `Never`. Without this fix when running with
`--enable-experiment=non-nullable` and a predicate callback with an
argument type other than `dynamic` or `Object?` the matcher wrapping
would fall through to use `equals` instead of wrapping as a predicate.

Add a regression test that previously fails as long as the test is run
with the experiment enabled. Without the experiment (or when running
with a predicate from opt-out code) the wrapping continued to work.