### PR TITLE
Remove private _Predicate typedef

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -5,6 +5,7 @@ analyzer:
 linter:
   rules:
     - avoid_function_literals_in_foreach_calls
+    - avoid_private_typedef_functions
     - avoid_renaming_method_parameters
     - avoid_returning_null
     - avoid_returning_null_for_future

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -6,8 +6,6 @@ import 'core_matchers.dart';
 import 'equals_matcher.dart';
 import 'interfaces.dart';
 
-typedef _Predicate<T> = bool Function(T value);
-
 /// A [Map] between whitespace characters and their escape sequences.
 const _escapeMap = {
   '\n': r'\n',
@@ -39,10 +37,10 @@ void addStateInfo(Map matchState, Map values) {
 Matcher wrapMatcher(x) {
   if (x is Matcher) {
     return x;
-  } else if (x is _Predicate<Object?>) {
+  } else if (x is bool Function(Object?)) {
     // x is already a predicate that can handle anything
     return predicate(x);
-  } else if (x is _Predicate<Never>) {
+  } else if (x is bool Function(Never)) {
     // x is a unary predicate, but expects a specific type
     // so wrap it.
     // ignore: unnecessary_lambdas


### PR DESCRIPTION
This shares the same name as the class in a different library which
makes it confusing. Private typedefs go against best practices and the
inline function types are more readable than trying to figure out what
the generic means.