### PR TITLE
Prepare for the 2.11 dev SDKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.12.10-nullsafety.1
+
+- Allow 2.10 stable and 2.11.0 dev SDK versions.
+
 ## 0.12.10-nullsafety
 
 - Migrate to NNBD.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: matcher
-version: 0.12.10-nullsafety
+version: 0.12.10-nullsafety.1
 
 description: >-
   Support for specifying test expectations via an extensible Matcher class.
@@ -8,7 +8,7 @@ homepage: https://github.com/dart-lang/matcher
 
 environment:
   # This must remain a tight constraint until nnbd is stable
-  sdk: '>=2.10.0-0 <2.10.0'
+  sdk: '>=2.10.0-0 <2.11.0'
 
 dependencies:
   stack_trace: '>=1.10.0-nullsafety <1.10.0'


### PR DESCRIPTION
Bump the upper bound to allow 2.10 stable and 2.11.0 dev SDK versions.