### PR TITLE
Make the item argument to Match dynamic again

### DIFF
--- a/lib/src/interfaces.dart
+++ b/lib/src/interfaces.dart
@@ -54,7 +54,7 @@ abstract class Matcher {
   /// A few matchers make use of the [verbose] flag to provide detailed
   /// information that is not typically included but can be of help in
   /// diagnosing failures, such as stack traces.
-  Description describeMismatch(Object? item, Description mismatchDescription,
+  Description describeMismatch(dynamic item, Description mismatchDescription,
           Map matchState, bool verbose) =>
       mismatchDescription;
 }

--- a/lib/src/interfaces.dart
+++ b/lib/src/interfaces.dart
@@ -39,7 +39,7 @@ abstract class Matcher {
   /// [item] is the actual value. [matchState] can be supplied
   /// and may be used to add details about the mismatch that are too
   /// costly to determine in [describeMismatch].
-  bool matches(Object? item, Map matchState);
+  bool matches(dynamic item, Map matchState);
 
   /// Builds a textual description of the matcher.
   Description describe(Description description);


### PR DESCRIPTION
This argument had been implicitly dynamic. #162 made it `Object?` which
can cause analysis errors that are otherwise hidden due to implicit
casts. Any classes which implement `Matcher` and override `match` could
omit the argument type, which inherits from the parent. When that
became `Object?` the cast to some other type coming from `dynamic`
must now be explicit.