### PR TITLE
Make argument to featureValueOf dynamic

### DIFF
--- a/lib/src/custom_matcher.dart
+++ b/lib/src/custom_matcher.dart
@@ -40,7 +40,7 @@ class CustomMatcher extends Matcher {
       : _matcher = wrapMatcher(valueOrMatcher);
 
   /// Override this to extract the interesting feature.
-  Object? featureValueOf(Object? actual) => actual;
+  Object? featureValueOf(dynamic actual) => actual;
 
   @override
   bool matches(Object? item, Map matchState) {


### PR DESCRIPTION
Similar to #163 changing the argument type from implicit `dynamic` to
`Object` for implementations that don't specify the type since inference
will pick the argument type from the overridden method.