### PR TITLE
Revert some changes since the latest published

### DIFF
--- a/lib/mirror_matchers.dart
+++ b/lib/mirror_matchers.dart
@@ -14,7 +14,7 @@ import 'matcher.dart';
 /// Returns a matcher that checks if a class instance has a property
 /// with name [name], and optionally, if that property in turn satisfies
 /// a [matcher].
-Matcher hasProperty(String name, [Object? matcher]) =>
+Matcher hasProperty(String name, [matcher]) =>
     _HasProperty(name, matcher == null ? null : wrapMatcher(matcher));
 
 class _HasProperty extends Matcher {
@@ -24,7 +24,7 @@ class _HasProperty extends Matcher {
   const _HasProperty(this._name, [this._matcher]);
 
   @override
-  bool matches(Object? item, Map matchState) {
+  bool matches(item, Map matchState) {
     var mirror = reflect(item);
     var classMirror = mirror.type;
     var symbol = Symbol(_name);
@@ -63,8 +63,8 @@ class _HasProperty extends Matcher {
   }
 
   @override
-  Description describeMismatch(Object? item, Description mismatchDescription,
-      Map matchState, bool verbose) {
+  Description describeMismatch(
+      item, Description mismatchDescription, Map matchState, bool verbose) {
     var reason = matchState['reason'];
     if (reason != null) {
       mismatchDescription.add(reason as String);

--- a/lib/src/core_matchers.dart
+++ b/lib/src/core_matchers.dart
@@ -14,7 +14,7 @@ class _Empty extends Matcher {
   const _Empty();
 
   @override
-  bool matches(Object? item, Map matchState) => (item as dynamic).isEmpty;
+  bool matches(item, Map matchState) => item.isEmpty;
 
   @override
   Description describe(Description description) => description.add('empty');
@@ -27,7 +27,7 @@ class _NotEmpty extends Matcher {
   const _NotEmpty();
 
   @override
-  bool matches(Object? item, Map matchState) => (item as dynamic).isNotEmpty;
+  bool matches(item, Map matchState) => item.isNotEmpty;
 
   @override
   Description describe(Description description) => description.add('non-empty');
@@ -42,7 +42,7 @@ const Matcher isNotNull = _IsNotNull();
 class _IsNull extends Matcher {
   const _IsNull();
   @override
-  bool matches(Object? item, Map matchState) => item == null;
+  bool matches(item, Map matchState) => item == null;
   @override
   Description describe(Description description) => description.add('null');
 }
@@ -50,7 +50,7 @@ class _IsNull extends Matcher {
 class _IsNotNull extends Matcher {
   const _IsNotNull();
   @override
-  bool matches(Object? item, Map matchState) => item != null;
+  bool matches(item, Map matchState) => item != null;
   @override
   Description describe(Description description) => description.add('not null');
 }
@@ -64,7 +64,7 @@ const Matcher isFalse = _IsFalse();
 class _IsTrue extends Matcher {
   const _IsTrue();
   @override
-  bool matches(Object? item, Map matchState) => item == true;
+  bool matches(item, Map matchState) => item == true;
   @override
   Description describe(Description description) => description.add('true');
 }
@@ -72,7 +72,7 @@ class _IsTrue extends Matcher {
 class _IsFalse extends Matcher {
   const _IsFalse();
   @override
-  bool matches(Object? item, Map matchState) => item == false;
+  bool matches(item, Map matchState) => item == false;
   @override
   Description describe(Description description) => description.add('false');
 }
@@ -103,13 +103,13 @@ class _IsNotNaN extends FeatureMatcher<num> {
 
 /// Returns a matches that matches if the value is the same instance
 /// as [expected], using [identical].
-Matcher same(Object? expected) => _IsSameAs(expected);
+Matcher same(expected) => _IsSameAs(expected);
 
 class _IsSameAs extends Matcher {
   final Object? _expected;
   const _IsSameAs(this._expected);
   @override
-  bool matches(Object? item, Map matchState) => identical(item, _expected);
+  bool matches(item, Map matchState) => identical(item, _expected);
   // If all types were hashable we could show a hash here.
   @override
   Description describe(Description description) =>
@@ -122,7 +122,7 @@ const Matcher anything = _IsAnything();
 class _IsAnything extends Matcher {
   const _IsAnything();
   @override
-  bool matches(Object? item, Map matchState) => true;
+  bool matches(item, Map matchState) => true;
   @override
   Description describe(Description description) => description.add('anything');
 }
@@ -181,20 +181,24 @@ const isList = TypeMatcher<List>();
 
 /// Returns a matcher that matches if an object has a length property
 /// that matches [matcher].
-Matcher hasLength(Object? matcher) => _HasLength(wrapMatcher(matcher));
+Matcher hasLength(matcher) => _HasLength(wrapMatcher(matcher));
 
 class _HasLength extends Matcher {
   final Matcher _matcher;
   const _HasLength(this._matcher);
 
   @override
-  bool matches(Object? item, Map matchState) {
+  bool matches(item, Map matchState) {
     try {
-      final length = (item as dynamic).length;
-      return _matcher.matches(length, matchState);
+      // This is harmless code that will throw if no length property
+      // but subtle enough that an optimizer shouldn't strip it out.
+      if (item.length * item.length >= 0) {
+        return _matcher.matches(item.length, matchState);
+      }
     } catch (e) {
       return false;
     }
+    throw UnsupportedError('Should never get here');
   }
 
   @override
@@ -202,14 +206,20 @@ class _HasLength extends Matcher {
       description.add('an object with length of ').addDescriptionOf(_matcher);
 
   @override
-  Description describeMismatch(Object? item, Description mismatchDescription,
-      Map matchState, bool verbose) {
+  Description describeMismatch(
+      item, Description mismatchDescription, Map matchState, bool verbose) {
     try {
-      final length = (item as dynamic).length;
-      return mismatchDescription.add('has length of ').addDescriptionOf(length);
+      // We want to generate a different description if there is no length
+      // property; we use the same trick as in matches().
+      if (item.length * item.length >= 0) {
+        return mismatchDescription
+            .add('has length of ')
+            .addDescriptionOf(item.length);
+      }
     } catch (e) {
       return mismatchDescription.add('has no length property');
     }
+    throw UnsupportedError('Should never get here');
   }
 }
 
@@ -220,7 +230,7 @@ class _HasLength extends Matcher {
 /// for [Map]s it means the map has the key, and for [Iterable]s
 /// it means the iterable has a matching element. In the case of iterables,
 /// [expected] can itself be a matcher.
-Matcher contains(Object? expected) => _Contains(expected);
+Matcher contains(expected) => _Contains(expected);
 
 class _Contains extends Matcher {
   final Object? _expected;
@@ -228,7 +238,7 @@ class _Contains extends Matcher {
   const _Contains(this._expected);
 
   @override
-  bool matches(Object? item, Map matchState) {
+  bool matches(item, Map matchState) {
     var expected = _expected;
     if (item is String) {
       return expected is Pattern && item.contains(expected);
@@ -249,8 +259,8 @@ class _Contains extends Matcher {
       description.add('contains ').addDescriptionOf(_expected);
 
   @override
-  Description describeMismatch(Object? item, Description mismatchDescription,
-      Map matchState, bool verbose) {
+  Description describeMismatch(
+      item, Description mismatchDescription, Map matchState, bool verbose) {
     if (item is String || item is Iterable || item is Map) {
       return super
           .describeMismatch(item, mismatchDescription, matchState, verbose);
@@ -262,7 +272,7 @@ class _Contains extends Matcher {
 
 /// Returns a matcher that matches if the match argument is in
 /// the expected value. This is the converse of [contains].
-Matcher isIn(Object? expected) {
+Matcher isIn(expected) {
   if (expected is Iterable) {
     return _In(expected, expected.contains);
   } else if (expected is String) {

--- a/lib/src/custom_matcher.dart
+++ b/lib/src/custom_matcher.dart
@@ -35,15 +35,14 @@ class CustomMatcher extends Matcher {
   final String _featureName;
   final Matcher _matcher;
 
-  CustomMatcher(
-      this._featureDescription, this._featureName, Object? valueOrMatcher)
-      : _matcher = wrapMatcher(valueOrMatcher);
+  CustomMatcher(this._featureDescription, this._featureName, matcher)
+      : _matcher = wrapMatcher(matcher);
 
   /// Override this to extract the interesting feature.
-  Object? featureValueOf(dynamic actual) => actual;
+  Object? featureValueOf(actual) => actual;
 
   @override
-  bool matches(Object? item, Map matchState) {
+  bool matches(item, Map matchState) {
     try {
       var f = featureValueOf(item);
       if (_matcher.matches(f, matchState)) return true;
@@ -69,8 +68,8 @@ class CustomMatcher extends Matcher {
       description.add(_featureDescription).add(' ').addDescriptionOf(_matcher);
 
   @override
-  Description describeMismatch(Object? item, Description mismatchDescription,
-      Map matchState, bool verbose) {
+  Description describeMismatch(
+      item, Description mismatchDescription, Map matchState, bool verbose) {
     if (matchState['custom.exception'] != null) {
       mismatchDescription
           .add('threw ')

--- a/lib/src/description.dart
+++ b/lib/src/description.dart
@@ -42,7 +42,7 @@ class StringDescription implements Description {
   /// escaping any embedded control characters; otherwise use its
   /// toString() value and wrap it in angular "quotes".
   @override
-  Description addDescriptionOf(Object? value) {
+  Description addDescriptionOf(value) {
     if (value is Matcher) {
       value.describe(this);
     } else {

--- a/lib/src/equals_matcher.dart
+++ b/lib/src/equals_matcher.dart
@@ -15,7 +15,7 @@ import 'util.dart';
 /// For [Iterable]s and [Map]s, this will recursively match the elements. To
 /// handle cyclic structures a recursion depth [limit] can be provided. The
 /// default limit is 100. [Set]s will be compared order-independently.
-Matcher equals(Object? expected, [int limit = 100]) => expected is String
+Matcher equals(expected, [int limit = 100]) => expected is String
     ? _StringEqualsMatcher(expected)
     : _DeepMatcher(expected, limit);
 
@@ -267,8 +267,8 @@ class _DeepMatcher extends Matcher {
       description.addDescriptionOf(_expected);
 
   @override
-  Description describeMismatch(Object? item, Description mismatchDescription,
-      Map matchState, bool verbose) {
+  Description describeMismatch(
+      item, Description mismatchDescription, Map matchState, bool verbose) {
     var mismatch = matchState['mismatch'] as _Mismatch;
     var describeProblem = mismatch.describeProblem;
     if (mismatch.location.isNotEmpty) {

--- a/lib/src/feature_matcher.dart
+++ b/lib/src/feature_matcher.dart
@@ -18,8 +18,8 @@ abstract class FeatureMatcher<T> extends TypeMatcher<T> {
   bool typedMatches(T item, Map matchState);
 
   @override
-  Description describeMismatch(Object? item, Description mismatchDescription,
-      Map matchState, bool verbose) {
+  Description describeMismatch(
+      item, Description mismatchDescription, Map matchState, bool verbose) {
     if (item is T) {
       return describeTypedMismatch(
           item, mismatchDescription, matchState, verbose);

--- a/lib/src/having_matcher.dart
+++ b/lib/src/having_matcher.dart
@@ -39,8 +39,8 @@ class HavingMatcher<T> implements TypeMatcher<T> {
   }
 
   @override
-  Description describeMismatch(Object? item, Description mismatchDescription,
-      Map matchState, bool verbose) {
+  Description describeMismatch(
+      item, Description mismatchDescription, Map matchState, bool verbose) {
     var matcher = matchState['matcher'] as Matcher;
     matcher.describeMismatch(
         item, mismatchDescription, matchState['state'] as Map, verbose);
@@ -56,9 +56,9 @@ class HavingMatcher<T> implements TypeMatcher<T> {
 }
 
 class _FunctionMatcher<T> extends CustomMatcher {
-  final Object? Function(T value) _feature;
+  final dynamic Function(T value) _feature;
 
-  _FunctionMatcher(String name, this._feature, Object? matcher)
+  _FunctionMatcher(String name, this._feature, matcher)
       : super('`$name`:', '`$name`', matcher);
 
   @override

--- a/lib/src/interfaces.dart
+++ b/lib/src/interfaces.dart
@@ -18,7 +18,7 @@ abstract class Description {
   Description add(String text);
 
   /// This is used to add a meaningful description of a value.
-  Description addDescriptionOf(Object? value);
+  Description addDescriptionOf(value);
 
   /// This is used to add a description of an [Iterable] [list],
   /// with appropriate [start] and [end] markers and inter-element [separator].
@@ -39,7 +39,7 @@ abstract class Matcher {
   /// [item] is the actual value. [matchState] can be supplied
   /// and may be used to add details about the mismatch that are too
   /// costly to determine in [describeMismatch].
-  bool matches(dynamic item, Map matchState);
+  bool matches(item, Map matchState);
 
   /// Builds a textual description of the matcher.
   Description describe(Description description);
@@ -54,7 +54,7 @@ abstract class Matcher {
   /// A few matchers make use of the [verbose] flag to provide detailed
   /// information that is not typically included but can be of help in
   /// diagnosing failures, such as stack traces.
-  Description describeMismatch(dynamic item, Description mismatchDescription,
+  Description describeMismatch(item, Description mismatchDescription,
           Map matchState, bool verbose) =>
       mismatchDescription;
 }

--- a/lib/src/iterable_matchers.dart
+++ b/lib/src/iterable_matchers.dart
@@ -9,9 +9,8 @@ import 'interfaces.dart';
 import 'util.dart';
 
 /// Returns a matcher which matches [Iterable]s in which all elements
-/// match the given [valueOrMatcher].
-Matcher everyElement(Object? valueOrMatcher) =>
-    _EveryElement(wrapMatcher(valueOrMatcher));
+/// match the given [matcher].
+Matcher everyElement(matcher) => _EveryElement(wrapMatcher(matcher));
 
 class _EveryElement extends _IterableMatcher {
   final Matcher _matcher;
@@ -63,9 +62,8 @@ class _EveryElement extends _IterableMatcher {
 }
 
 /// Returns a matcher which matches [Iterable]s in which at least one
-/// element matches the given [valueOrMatcher].
-Matcher anyElement(Object? valueOrMatcher) =>
-    _AnyElement(wrapMatcher(valueOrMatcher));
+/// element matches the given [matcher].
+Matcher anyElement(matcher) => _AnyElement(wrapMatcher(matcher));
 
 class _AnyElement extends _IterableMatcher {
   final Matcher _matcher;

--- a/lib/src/map_matchers.dart
+++ b/lib/src/map_matchers.dart
@@ -6,7 +6,7 @@ import 'interfaces.dart';
 import 'util.dart';
 
 /// Returns a matcher which matches maps containing the given [value].
-Matcher containsValue(Object? value) => _ContainsValue(value);
+Matcher containsValue(value) => _ContainsValue(value);
 
 class _ContainsValue extends Matcher {
   final Object? _value;
@@ -14,17 +14,15 @@ class _ContainsValue extends Matcher {
   const _ContainsValue(this._value);
 
   @override
-  bool matches(Object? item, Map matchState) =>
-      (item as dynamic).containsValue(_value);
+  bool matches(item, Map matchState) => item.containsValue(_value);
   @override
   Description describe(Description description) =>
       description.add('contains value ').addDescriptionOf(_value);
 }
 
 /// Returns a matcher which matches maps containing the key-value pair
-/// with [key] => [valueOrMatcher].
-Matcher containsPair(Object? key, Object? valueOrMatcher) =>
-    _ContainsMapping(key, wrapMatcher(valueOrMatcher));
+/// with [key] => [value].
+Matcher containsPair(key, value) => _ContainsMapping(key, wrapMatcher(value));
 
 class _ContainsMapping extends Matcher {
   final Object? _key;
@@ -33,9 +31,8 @@ class _ContainsMapping extends Matcher {
   const _ContainsMapping(this._key, this._valueMatcher);
 
   @override
-  bool matches(Object? item, Map matchState) =>
-      (item as dynamic).containsKey(_key) &&
-      _valueMatcher.matches(item[_key], matchState);
+  bool matches(item, Map matchState) =>
+      item.containsKey(_key) && _valueMatcher.matches(item[_key], matchState);
 
   @override
   Description describe(Description description) {
@@ -47,9 +44,9 @@ class _ContainsMapping extends Matcher {
   }
 
   @override
-  Description describeMismatch(Object? item, Description mismatchDescription,
-      Map matchState, bool verbose) {
-    if (!(item as dynamic).containsKey(_key)) {
+  Description describeMismatch(
+      item, Description mismatchDescription, Map matchState, bool verbose) {
+    if (!item.containsKey(_key)) {
       return mismatchDescription
           .add(" doesn't contain key ")
           .addDescriptionOf(_key);

--- a/lib/src/operator_matchers.dart
+++ b/lib/src/operator_matchers.dart
@@ -5,8 +5,8 @@
 import 'interfaces.dart';
 import 'util.dart';
 
-/// Returns a matcher that inverts [valueOrMatcher] to its logical negation.
-Matcher isNot(Object? valueOrMatcher) => _IsNot(wrapMatcher(valueOrMatcher));
+/// This returns a matcher that inverts [matcher] to its logical negation.
+Matcher isNot(matcher) => _IsNot(wrapMatcher(matcher));
 
 class _IsNot extends Matcher {
   final Matcher _matcher;
@@ -27,13 +27,7 @@ class _IsNot extends Matcher {
 /// Instead of passing the matchers separately they can be passed as a single
 /// List argument. Any argument that is not a matcher is implicitly wrapped in a
 /// Matcher to check for equality.
-Matcher allOf(Object? arg0,
-    [Object? arg1,
-    Object? arg2,
-    Object? arg3,
-    Object? arg4,
-    Object? arg5,
-    Object? arg6]) {
+Matcher allOf(arg0, [arg1, arg2, arg3, arg4, arg5, arg6]) {
   return _AllOf(_wrapArgs(arg0, arg1, arg2, arg3, arg4, arg5, arg6));
 }
 
@@ -77,13 +71,7 @@ class _AllOf extends Matcher {
 ///
 /// Any argument that is not a matcher is implicitly wrapped in a
 /// Matcher to check for equality.
-Matcher anyOf(Object? arg0,
-    [Object? arg1,
-    Object? arg2,
-    Object? arg3,
-    Object? arg4,
-    Object? arg5,
-    Object? arg6]) {
+Matcher anyOf(arg0, [arg1, arg2, arg3, arg4, arg5, arg6]) {
   return _AnyOf(_wrapArgs(arg0, arg1, arg2, arg3, arg4, arg5, arg6));
 }
 
@@ -107,8 +95,7 @@ class _AnyOf extends Matcher {
       description.addAll('(', ' or ', ')', _matchers);
 }
 
-List<Matcher> _wrapArgs(Object? arg0, Object? arg1, Object? arg2, Object? arg3,
-    Object? arg4, Object? arg5, Object? arg6) {
+List<Matcher> _wrapArgs(arg0, arg1, arg2, arg3, arg4, arg5, arg6) {
   Iterable args;
   if (arg0 is List) {
     if (arg1 != null ||

--- a/lib/src/order_matchers.dart
+++ b/lib/src/order_matchers.dart
@@ -6,22 +6,22 @@ import 'interfaces.dart';
 
 /// Returns a matcher which matches if the match argument is greater
 /// than the given [value].
-Matcher greaterThan(Object value) =>
+Matcher greaterThan(value) =>
     _OrderingMatcher(value, false, false, true, 'a value greater than');
 
 /// Returns a matcher which matches if the match argument is greater
 /// than or equal to the given [value].
-Matcher greaterThanOrEqualTo(Object value) => _OrderingMatcher(
+Matcher greaterThanOrEqualTo(value) => _OrderingMatcher(
     value, true, false, true, 'a value greater than or equal to');
 
 /// Returns a matcher which matches if the match argument is less
 /// than the given [value].
-Matcher lessThan(Object value) =>
+Matcher lessThan(value) =>
     _OrderingMatcher(value, false, true, false, 'a value less than');
 
 /// Returns a matcher which matches if the match argument is less
 /// than or equal to the given [value].
-Matcher lessThanOrEqualTo(Object value) =>
+Matcher lessThanOrEqualTo(value) =>
     _OrderingMatcher(value, true, true, false, 'a value less than or equal to');
 
 /// A matcher which matches if the match argument is zero.
@@ -75,10 +75,10 @@ class _OrderingMatcher extends Matcher {
       : _valueInDescription = valueInDescription;
 
   @override
-  bool matches(Object? item, Map matchState) {
+  bool matches(item, Map matchState) {
     if (item == _value) {
       return _equalValue;
-    } else if ((item as dynamic) < _value) {
+    } else if (item < _value) {
       return _lessThanValue;
     } else if (item > _value) {
       return _greaterThanValue;

--- a/lib/src/pretty_print.dart
+++ b/lib/src/pretty_print.dart
@@ -15,8 +15,8 @@ import 'util.dart';
 ///
 /// If [maxItems] is passed, [Iterable]s and [Map]s will only print their first
 /// [maxItems] members or key/value pairs, respectively.
-String prettyPrint(Object? object, {int? maxLineLength, int? maxItems}) {
-  String _prettyPrint(Object? object, int indent, Set<Object?> seen, bool top) {
+String prettyPrint(object, {int? maxLineLength, int? maxItems}) {
+  String _prettyPrint(object, int indent, Set<Object?> seen, bool top) {
     // If the object is a matcher, use its description.
     if (object is Matcher) {
       var description = StringDescription();
@@ -27,7 +27,7 @@ String prettyPrint(Object? object, {int? maxLineLength, int? maxItems}) {
     // Avoid looping infinitely on recursively-nested data structures.
     if (seen.contains(object)) return '(recursive)';
     seen = seen.union({object});
-    String pp(Object? child) => _prettyPrint(child, indent + 2, seen, false);
+    String pp(child) => _prettyPrint(child, indent + 2, seen, false);
 
     if (object is Iterable) {
       // Print the type name for non-List iterables.
@@ -123,7 +123,7 @@ String _indent(int length) => List.filled(length, ' ').join('');
 
 /// Returns the name of the type of [x] with fallbacks for core types with
 /// private implementations.
-String _typeName(Object x) {
+String _typeName(x) {
   if (x is Type) return 'Type';
   if (x is Uri) return 'Uri';
   if (x is Set) return 'Set';

--- a/lib/src/string_matchers.dart
+++ b/lib/src/string_matchers.dart
@@ -138,12 +138,12 @@ class _StringContainsInOrder extends FeatureMatcher<String> {
 ///
 /// [re] can be a [RegExp] instance or a [String]; in the latter case it will be
 /// used to create a RegExp instance.
-Matcher matches(Pattern re) => _MatchesRegExp(re);
+Matcher matches(re) => _MatchesRegExp(re);
 
 class _MatchesRegExp extends FeatureMatcher<String> {
   final RegExp _regexp;
 
-  _MatchesRegExp(Pattern re)
+  _MatchesRegExp(re)
       : _regexp = (re is String)
             ? RegExp(re)
             : (re is RegExp)

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -34,19 +34,19 @@ void addStateInfo(Map matchState, Map values) {
 /// If the argument is already a matcher this does nothing,
 /// else if the argument is a function, it generates a predicate
 /// function matcher, else it generates an equals matcher.
-Matcher wrapMatcher(Object? valueOrMatcher) {
-  if (valueOrMatcher is Matcher) {
-    return valueOrMatcher;
-  } else if (valueOrMatcher is bool Function(Object?)) {
-    // already a predicate that can handle anything
-    return predicate(valueOrMatcher);
-  } else if (valueOrMatcher is bool Function(Never)) {
-    // unary predicate, but expects a specific type
+Matcher wrapMatcher(x) {
+  if (x is Matcher) {
+    return x;
+  } else if (x is bool Function(Object?)) {
+    // x is already a predicate that can handle anything
+    return predicate(x);
+  } else if (x is bool Function(Never)) {
+    // x is a unary predicate, but expects a specific type
     // so wrap it.
     // ignore: unnecessary_lambdas
-    return predicate((a) => (valueOrMatcher as dynamic)(a));
+    return predicate((a) => (x as dynamic)(a));
   } else {
-    return equals(valueOrMatcher);
+    return equals(x);
   }
 }
 

--- a/test/custom_matcher_test.dart
+++ b/test/custom_matcher_test.dart
@@ -14,10 +14,9 @@ class _BadCustomMatcher extends CustomMatcher {
 }
 
 class _HasPrice extends CustomMatcher {
-  _HasPrice(Object? matcher)
-      : super('Widget with a price that is', 'price', matcher);
+  _HasPrice(matcher) : super('Widget with a price that is', 'price', matcher);
   @override
-  Object? featureValueOf(Object? actual) => (actual as Widget).price;
+  Object? featureValueOf(actual) => (actual as Widget).price;
 }
 
 void main() {

--- a/test/having_test.dart
+++ b/test/having_test.dart
@@ -108,7 +108,7 @@ final _rangeMatcher = isRangeError
     .having((e) => e.start, 'start', isNull)
     .having((e) => e.end, 'end', isNull);
 
-Matcher _hasPrice(Object matcher) =>
+Matcher _hasPrice(matcher) =>
     const TypeMatcher<Widget>().having((e) => e.price, 'price', matcher);
 
 Matcher _badCustomMatcher() => const TypeMatcher<Widget>()

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -4,7 +4,7 @@
 
 import 'package:test/test.dart';
 
-void shouldFail(Object? value, Matcher matcher, Object? expected) {
+void shouldFail(value, Matcher matcher, expected) {
   var failed = false;
   try {
     expect(value, matcher);
@@ -23,7 +23,7 @@ void shouldFail(Object? value, Matcher matcher, Object? expected) {
   expect(failed, isTrue, reason: 'Expected to fail.');
 }
 
-void shouldPass(Object? value, Matcher matcher) {
+void shouldPass(value, Matcher matcher) {
   expect(value, matcher);
 }
 


### PR DESCRIPTION
Rolls back some changes which are not trivially safe out of caution so
that the first stable version published will match exactly with the last
published pre-release. These changes will be rolled forward in a feature
release - they are expected to be non-breaking and internal code is
already using this version.

This reverts commits
- 2071cfd84b3ede7277c57d122ef8c74cf0f3c6f0
- 71eeaee1cb8235a47e47bcad9134f744bb1c594a
- 63f1110a657fb5e2dc378db8895fef7b0a13ab30

This does not revert one code change which makes the migration easier
for users using the `same` matcher against nullable types.
- 5d52720b8cdb8ddcc4256950618650e7eabc4176