### PR TITLE
Move from pedantic to lints package

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:pedantic/analysis_options.yaml
+include: package:lints/recommended.yaml
 
 linter:
   rules:

--- a/lib/mirror_matchers.dart
+++ b/lib/mirror_matchers.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-@Deprecated('Check propertie on known types')
+@Deprecated('Check properties on known types')
 library mirror_matchers;
 
 /// The mirror matchers library provides some additional matchers that

--- a/lib/mirror_matchers.dart
+++ b/lib/mirror_matchers.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-@deprecated
+@Deprecated('Check propertie on known types')
 library mirror_matchers;
 
 /// The mirror matchers library provides some additional matchers that

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,13 +7,13 @@ description: >-
 homepage: https://github.com/dart-lang/matcher
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   stack_trace: ^1.10.0
 
 dev_dependencies:
-  pedantic: ^1.10.0-nullsafety
+  lints: ^1.0.0
   test: any
   test_api: any
   test_core: any

--- a/test/core_matchers_test.dart
+++ b/test/core_matchers_test.dart
@@ -229,7 +229,7 @@ void main() {
       shouldPass('cow', predicate((x) => x is String, 'an instance of String'));
 
       shouldFail(0, predicate((bool x) => x, 'bool value is true'),
-          endsWith("not an <Instance of \'bool\'>"));
+          endsWith("not an <Instance of 'bool'>"));
     });
   });
 

--- a/test/iterable_matchers_test.dart
+++ b/test/iterable_matchers_test.dart
@@ -242,7 +242,7 @@ void main() {
         containsAll([1]),
         'Expected: contains all of [1] '
         'Actual: <1> '
-        "Which: not an <Instance of \'Iterable\'>");
+        "Which: not an <Instance of 'Iterable'>");
     shouldFail(
         [-1, 2],
         containsAll([greaterThan(0), greaterThan(1)]),
@@ -285,7 +285,7 @@ void main() {
         containsAllInOrder([1]),
         'Expected: contains in order([1]) '
         'Actual: <1> '
-        "Which: not an <Instance of \'Iterable\'>");
+        "Which: not an <Instance of 'Iterable'>");
   });
 
   test('pairwise compare', () {
@@ -297,7 +297,7 @@ void main() {
         pairwiseCompare(e, (int e, int a) => a <= e, 'less than or equal'),
         'Expected: pairwise less than or equal [1, 4, 9] '
             "Actual: 'x' "
-            "Which: not an <Instance of \'Iterable\'>");
+            "Which: not an <Instance of 'Iterable'>");
     shouldFail(
         c,
         pairwiseCompare(e, (int e, int a) => a <= e, 'less than or equal'),


### PR DESCRIPTION
Fix existing violations of lints:
- `provide_deprecation_message`
- `unnecessary_string_escapes`