### PR TITLE
Add a Best Practices section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ why the test failed. For instance compare the failures between
 ```
 // expect(someList.length, 1);
   Expected: <1>
-    Actual: <0>
+    Actual: <2>
 ```
 
 ```
 // expect(someList, hasLength(1));
   Expected: an object with length of <1>
-    Actual: []
+    Actual: ['expected value', 'unexpected value']
      Which: has length of <0>
 
 ```

--- a/README.md
+++ b/README.md
@@ -5,3 +5,26 @@ inspiration from [Hamcrest](https://code.google.com/p/hamcrest/).
 
 For more information, see
 [Unit Testing with Dart](https://github.com/dart-lang/test/blob/master/pkgs/test/README.md#writing-tests).
+
+# Best Practices
+
+## Prefer semantically meaningful matchers to comparing derived values
+
+Matchers which have knowledge of the semantics that are tested are able to emit
+more meaningful messages which don't require reading test source to understand
+why the test failed. For instance compare the failures between
+`expect(someList.length, 1)`, and `expect(someList, hasLength(1))`:
+
+```
+// expect(someList.length, 1);
+  Expected: <1>
+    Actual: <0>
+```
+
+```
+// expect(someList, hasLength(1));
+  Expected: an object with length of <1>
+    Actual: []
+     Which: has length of <0>
+
+```

--- a/README.md
+++ b/README.md
@@ -25,6 +25,6 @@ why the test failed. For instance compare the failures between
 // expect(someList, hasLength(1));
   Expected: an object with length of <1>
     Actual: ['expected value', 'unexpected value']
-     Which: has length of <0>
+     Which: has length of <2>
 
 ```


### PR DESCRIPTION
The goal is to have some place to link to for common guidance given in
code reviews instead of having to repeat a snippet of explanation each
time.

For now add a single common code review comment. More can be added if
other common comments are identified.