### PR TITLE
Stop depending on the deprecated `CastError` type.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-## 0.12.13-dev
+## 0.12.13
 
 * Require Dart 2.17 or greater.
+* Add `isTypeError`
+* Make `isCastError` no longer depend on the deprecated `CastError` type.
 
 ## 0.12.12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## 0.12.13
 
 * Require Dart 2.17 or greater.
-* Add `isTypeError`
 * Make `isCastError` no longer depend on the deprecated `CastError` type.
 
 ## 0.12.12

--- a/lib/src/error_matchers.dart
+++ b/lib/src/error_matchers.dart
@@ -9,7 +9,7 @@ const isArgumentError = TypeMatcher<ArgumentError>();
 
 /// A matcher for [TypeError].
 @Deprecated('CastError has been deprecated in favor of TypeError. ')
-const isCastError = isTypeError;
+const isCastError = TypeMatcher<TypeError>();
 
 /// A matcher for [ConcurrentModificationError].
 const isConcurrentModificationError =
@@ -35,9 +35,6 @@ const isRangeError = TypeMatcher<RangeError>();
 
 /// A matcher for [StateError].
 const isStateError = TypeMatcher<StateError>();
-
-/// A matcher for [TypeError].
-const isTypeError = TypeMatcher<TypeError>();
 
 /// A matcher for [UnimplementedError].
 const isUnimplementedError = TypeMatcher<UnimplementedError>();

--- a/lib/src/error_matchers.dart
+++ b/lib/src/error_matchers.dart
@@ -7,11 +7,9 @@ import 'type_matcher.dart';
 /// A matcher for [ArgumentError].
 const isArgumentError = TypeMatcher<ArgumentError>();
 
-/// A matcher for [CastError].
-@Deprecated('CastError has been deprecated in favor of TypeError. '
-    'Use `isA<TypeError>()` or, if you need compatibility with older SDKs, '
-    'use `isA<CastError>()` and ignore the deprecation.')
-const isCastError = TypeMatcher<CastError>();
+/// A matcher for [TypeError].
+@Deprecated('CastError has been deprecated in favor of TypeError. ')
+const isCastError = isTypeError;
 
 /// A matcher for [ConcurrentModificationError].
 const isConcurrentModificationError =
@@ -37,6 +35,9 @@ const isRangeError = TypeMatcher<RangeError>();
 
 /// A matcher for [StateError].
 const isStateError = TypeMatcher<StateError>();
+
+/// A matcher for [TypeError].
+const isTypeError = TypeMatcher<TypeError>();
 
 /// A matcher for [UnimplementedError].
 const isUnimplementedError = TypeMatcher<UnimplementedError>();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: matcher
-version: 0.12.13-dev
+version: 0.12.13
 description: >-
   Support for specifying test expectations via an extensible Matcher class.
   Also includes a number of built-in Matcher implementations for common cases.

--- a/test/type_matcher_test.dart
+++ b/test/type_matcher_test.dart
@@ -12,7 +12,7 @@ void main() {
   _test(isList, [], name: 'List');
   _test(isArgumentError, ArgumentError());
   // ignore: deprecated_member_use, deprecated_member_use_from_same_package
-  _test(isTypeError, TypeError());
+  _test(isCastError, TypeError());
   _test<Exception>(isException, const FormatException());
   _test(isFormatException, const FormatException());
   _test(isStateError, StateError('oops'));

--- a/test/type_matcher_test.dart
+++ b/test/type_matcher_test.dart
@@ -12,7 +12,7 @@ void main() {
   _test(isList, [], name: 'List');
   _test(isArgumentError, ArgumentError());
   // ignore: deprecated_member_use, deprecated_member_use_from_same_package
-  _test(isCastError, CastError());
+  _test(isTypeError, TypeError());
   _test<Exception>(isException, const FormatException());
   _test(isFormatException, const FormatException());
   _test(isStateError, StateError('oops'));


### PR DESCRIPTION
Add `isTypeError` as alternative.

This is the source of the majority of the breakage from the CL to remove `CastError` from the SDK: https://dart-review.googlesource.com/c/sdk/+/258003