### PR TITLE
Bump min SDK to 2.18.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       matrix:
         # Add macos-latest and/or windows-latest if relevant for this package.
         os: [ubuntu-latest]
-        sdk: [2.17.0, dev]
+        sdk: [2.18.0, dev]
     steps:
       - uses: actions/checkout@v3
       - uses: dart-lang/setup-dart@v1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ description: >-
 repository: https://github.com/dart-lang/matcher
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=2.18.0 <3.0.0"
 
 dependencies:
   meta: ^1.8.0


### PR DESCRIPTION
The `test` package has this lower bound, so no real world usage can resolve a newer `matcher` without a 2.18 SDK.