### PR TITLE
Stop using deprecated errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Add `containsOnce` matcher.
 * Deprecate `isCyclicInitializationError` and `NullThrownError`. These errors
+  will be removed from the SDK. Update them to catch more general errors.
 
 ## 0.12.13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.12.14
+
+* Deprecate `isCyclicInitializationError` and `NullThrownError`. These errors
+  will be removed from the SDK. Update them to catch more general errors.
+
 ## 0.12.13
 
 * Require Dart 2.17 or greater.

--- a/lib/src/error_matchers.dart
+++ b/lib/src/error_matchers.dart
@@ -15,7 +15,7 @@ const isCastError = TypeMatcher<TypeError>();
 const isConcurrentModificationError =
     TypeMatcher<ConcurrentModificationError>();
 
-/// A matcher for [CyclicInitializationError].
+/// A matcher for [Error].
 @Deprecated(
     'CyclicInitializationError is deprecated and will be removed in Dart 3. '
     'Use `isA<Error>()` instead.')
@@ -30,10 +30,10 @@ const isFormatException = TypeMatcher<FormatException>();
 /// A matcher for [NoSuchMethodError].
 const isNoSuchMethodError = TypeMatcher<NoSuchMethodError>();
 
-/// A matcher for [NullThrownError].
+/// A matcher for [TypeError].
 @Deprecated('NullThrownError is deprecated and will be removed in Dart 3. '
     'Use `isA<TypeError>()` instead.')
-const isNullThrownError = TypeMatcher<NullThrownError>();
+const isNullThrownError = TypeMatcher<TypeError>();
 
 /// A matcher for [RangeError].
 const isRangeError = TypeMatcher<RangeError>();

--- a/lib/src/error_matchers.dart
+++ b/lib/src/error_matchers.dart
@@ -16,7 +16,10 @@ const isConcurrentModificationError =
     TypeMatcher<ConcurrentModificationError>();
 
 /// A matcher for [CyclicInitializationError].
-const isCyclicInitializationError = TypeMatcher<CyclicInitializationError>();
+@Deprecated(
+    'CyclicInitializationError is deprecated and will be removed in Dart 3. '
+    'Use `isA<Error>()` instead.')
+const isCyclicInitializationError = TypeMatcher<Error>();
 
 /// A matcher for [Exception].
 const isException = TypeMatcher<Exception>();
@@ -28,6 +31,8 @@ const isFormatException = TypeMatcher<FormatException>();
 const isNoSuchMethodError = TypeMatcher<NoSuchMethodError>();
 
 /// A matcher for [NullThrownError].
+@Deprecated('NullThrownError is deprecated and will be removed in Dart 3. '
+    'Use `isA<TypeError>()` instead.')
 const isNullThrownError = TypeMatcher<NullThrownError>();
 
 /// A matcher for [RangeError].

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: matcher
-version: 0.12.13
+version: 0.12.14
 description: >-
   Support for specifying test expectations via an extensible Matcher class.
   Also includes a number of built-in Matcher implementations for common cases.

--- a/test/type_matcher_test.dart
+++ b/test/type_matcher_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// ignore_for_file: deprecated_member_use_from_same_package
 import 'package:matcher/matcher.dart';
 import 'package:test/test.dart' show test, group;
 
@@ -11,7 +12,6 @@ void main() {
   _test(isMap, {}, name: 'Map');
   _test(isList, [], name: 'List');
   _test(isArgumentError, ArgumentError());
-  // ignore: deprecated_member_use, deprecated_member_use_from_same_package
   _test(isCastError, TypeError());
   _test<Exception>(isException, const FormatException());
   _test(isFormatException, const FormatException());
@@ -20,13 +20,12 @@ void main() {
   _test(isUnimplementedError, UnimplementedError('oops'));
   _test(isUnsupportedError, UnsupportedError('oops'));
   _test(isConcurrentModificationError, ConcurrentModificationError());
-  _test(isCyclicInitializationError, CyclicInitializationError());
+  _test(isCyclicInitializationError, Error());
   _test<NoSuchMethodError?>(isNoSuchMethodError, null,
       name: 'NoSuchMethodError');
-  _test(isNullThrownError, NullThrownError());
+  _test(isNullThrownError, TypeError());
 
   group('custom `TypeMatcher`', () {
-    // ignore: deprecated_member_use_from_same_package
     _test(const isInstanceOf<String>(), 'hello');
     _test(const _StringMatcher(), 'hello');
     _test(const TypeMatcher<String>(), 'hello');
@@ -56,9 +55,7 @@ void _test<T>(Matcher typeMatcher, T matchingInstance, {String? name}) {
 
 // Validate that existing implementations continue to work.
 class _StringMatcher extends TypeMatcher {
-  const _StringMatcher() : super(
-            // ignore: deprecated_member_use_from_same_package
-            'String');
+  const _StringMatcher() : super('String');
 
   @override
   bool matches(dynamic item, Map matchState) => item is String;


### PR DESCRIPTION
Prepare for the errors to be removed from the SDK and stop referencing
them entirely. Deprecate the matchers for these errors and change the
types to target the more general `Error` and `TypeError` which will
still catch the same situations.

Move the ignore for same package deprecations to cover the entire test
file.
