### PR TITLE
reverted min dart sdk to 2.12

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -29,4 +29,3 @@ linter:
     - unnecessary_lambdas
     - unnecessary_parenthesis
     - unnecessary_statements
-    - use_super_parameters

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,14 +6,14 @@ description: >-
 repository: https://github.com/dart-lang/matcher
 
 environment:
-  sdk: ">=2.18.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   meta: ^1.8.0
   stack_trace: ^1.10.0
 
 dev_dependencies:
-  lints: ^2.0.0
+  lints: ^1.0.0
   test: any
   test_api: any
   test_core: any

--- a/test/having_test.dart
+++ b/test/having_test.dart
@@ -117,9 +117,8 @@ Matcher _badCustomMatcher() => const TypeMatcher<Widget>()
     .having((e) => throw Exception('bang'), 'feature', {1: 'a'});
 
 class CustomRangeError extends RangeError {
-  CustomRangeError.range(
-      super.invalidValue, int super.minValue, int super.maxValue)
-      : super.range();
+  CustomRangeError.range(invalidValue, int minValue, int maxValue)
+      : super.range(invalidValue, minValue, maxValue);
 
   @override
   String toString() => 'RangeError: Invalid value: details';


### PR DESCRIPTION
This PR reverts matcher to a min dart-sdk of 2.12 as per issue #203.

There is however a problem with the dependencies which doesn't make sense to me.

The test related packages all use a version of 'any'. I assume this is to make matcher compatible with all versions of the test related packages (even though my understanding is that you should never publish with any?).

The problem is with the test_api override.

I don't understand what the override is doing as test_api already is declared as any. However it clearly is doing something as without it version solving fails.

The problem is that when we have the test_api override `pub' selects the lastest version of test_api (0.4.17) which has a minimum sdk constraint of 2.17.
I don't understand why pub is selecting 0.4.17 given that I'm running dart 2.12. My understanding is that  the fact that I'm running 2.12  should have excluded 0.4.17 from being selected and instead a dart 2.12 compatible version of test_api should have been chosen.

If I change the override to a dart 2.12 compatible version of test_api all of the unit tests succeed.

The unit tests also succeed for dart 3.x using the test_api override with `any`.


