### PR TITLE
Improve mismatch description of `contains`

### DIFF
--- a/lib/src/core_matchers.dart
+++ b/lib/src/core_matchers.dart
@@ -252,8 +252,9 @@ class _Contains extends Matcher {
   Description describeMismatch(Object? item, Description mismatchDescription,
       Map matchState, bool verbose) {
     if (item is String || item is Iterable || item is Map) {
-      return super
-          .describeMismatch(item, mismatchDescription, matchState, verbose);
+      super.describeMismatch(item, mismatchDescription, matchState, verbose);
+      mismatchDescription.add('does not contain ').addDescriptionOf(_expected);
+      return mismatchDescription;
     } else {
       return mismatchDescription.add('is not a string, map or iterable');
     }

--- a/test/having_test.dart
+++ b/test/having_test.dart
@@ -21,7 +21,8 @@ void main() {
       "Expected: <Instance of 'RangeError'> with "
       "`message`: contains 'details' and `start`: null and `end`: null "
       'Actual: CustomRangeError:<RangeError: Invalid value: details> '
-      "Which: has `message` with value 'Invalid value'",
+      "Which: has `message` with value 'Invalid value' "
+      "which does not contain 'details'",
     );
   });
 
@@ -56,7 +57,8 @@ void main() {
               'Invalid value: Not in inclusive range 1..10: -1] '
               'Which: at location [0] is RangeError:<RangeError: '
               'Invalid value: Not in inclusive range 1..10: -1> '
-              "which has `message` with value 'Invalid value'"),
+              "which has `message` with value 'Invalid value' "
+              "which does not contain 'details'"),
           equalsIgnoringWhitespace(// Older SDKs
               "Expected: [ <<Instance of 'RangeError'> with "
               "`message`: contains 'details' and `start`: null and `end`: null> ] "
@@ -64,7 +66,8 @@ void main() {
               'Invalid value: Not in range 1..10, inclusive: -1] '
               'Which: at location [0] is RangeError:<RangeError: '
               'Invalid value: Not in range 1..10, inclusive: -1> '
-              "which has `message` with value 'Invalid value'")
+              "which has `message` with value 'Invalid value' "
+              "which does not contain 'details'")
         ]));
   });
 

--- a/test/iterable_matchers_test.dart
+++ b/test/iterable_matchers_test.dart
@@ -24,10 +24,14 @@ void main() {
         d,
         contains(0),
         'Expected: contains <0> '
-        'Actual: [1, 2]');
+        'Actual: [1, 2] '
+        'Which: does not contain <0>');
 
     shouldFail(
-        'String', contains(42), "Expected: contains <42> Actual: 'String'");
+        'String',
+        contains(42),
+        "Expected: contains <42> Actual: 'String' "
+            'Which: does not contain <42>');
   });
 
   test('equals with matcher element', () {
@@ -109,8 +113,7 @@ void main() {
         "Expected: every element((contains 'foo' and "
         'an object with length of a value greater than <0>)) '
         "Actual: [['foo', 'bar'], ['foo'], []] "
-        "Which: has value [] which doesn't match (contains 'foo' and "
-        'an object with length of a value greater than <0>) at index 2');
+        "Which: has value [] which does not contain 'foo' at index 2");
     shouldFail(
         e,
         everyElement(allOf(contains('foo'), hasLength(greaterThan(0)))),
@@ -386,6 +389,7 @@ void main() {
         d,
         contains(5),
         'Expected: contains <5> '
-        'Actual: SimpleIterable:[3, 2, 1]');
+        'Actual: SimpleIterable:[3, 2, 1] '
+        'Which: does not contain <5>');
   });
 }

--- a/test/map_matchers_test.dart
+++ b/test/map_matchers_test.dart
@@ -12,13 +12,15 @@ void main() {
       {'a': 1},
       contains(2),
       'Expected: contains <2> '
-      'Actual: {\'a\': 1}',
+      'Actual: {\'a\': 1} '
+      'Which: does not contain <2>',
     );
     shouldFail(
       {'a': 1},
       contains(null),
       'Expected: contains <null> '
-      'Actual: {\'a\': 1}',
+      'Actual: {\'a\': 1} '
+      'Which: does not contain <null>',
     );
   });
 

--- a/test/string_matchers_test.dart
+++ b/test/string_matchers_test.dart
@@ -103,8 +103,8 @@ void main() {
     shouldPass('hello', contains('o'));
     shouldPass('hello', contains('hell'));
     shouldPass('hello', contains('hello'));
-    shouldFail(
-        'hello', contains(' '), "Expected: contains ' ' Actual: 'hello'");
+    shouldFail('hello', contains(' '),
+        "Expected: contains ' ' Actual: 'hello' Which: does not contain ' '");
   });
 
   test('stringContainsInOrder', () {


### PR DESCRIPTION
This becomes important when combined with `allOf`.

Consider:
```dart
import 'package:test/test.dart';

main() {
  test('contains the right things', () {
    expect('abc', allOf(contains('a'), contains('b'), contains('d')));
  });
}
```

Before:
```
> dart test
00:02 +0 -1: contains the right things [E]                                                                         
  Expected: (contains 'a' and contains 'b' and contains 'd')
    Actual: 'abc'
  
  package:test_api      expect
  test/a_test.dart 5:5  main.<fn>
```

Notice how it is unclear which of the expectations that failed.

After:
```
> dart test
00:01 +0 -1: contains the right things [E]                                                                         
  Expected: (contains 'a' and contains 'b' and contains 'd')
    Actual: 'abc'
     Which: does not contain 'd'

  package:test_api      expect
  test/a_test.dart 5:5  main.<fn>
```