### PR TITLE
Fix import and broken tests

### DIFF
--- a/test/matcher/prints_test.dart
+++ b/test/matcher/prints_test.dart
@@ -62,7 +62,9 @@ void main() {
                 '  Actual: <'),
             endsWith('>\n'
                 "   Which: printed 'Hello, world!\\n'\n"
-                "                    ''\n")
+                "                    ''\n"
+                '            which does not contain \'Goodbye\'\n'
+                )
           ]));
     });
 
@@ -78,7 +80,9 @@ void main() {
             startsWith("Expected: prints contains 'Goodbye'\n"
                 '  Actual: <'),
             endsWith('>\n'
-                '   Which: printed nothing\n')
+                '   Which: printed nothing\n'
+                '            which does not contain \'Goodbye\'\n'
+                )
           ]));
     });
 

--- a/test/matcher/prints_test.dart
+++ b/test/matcher/prints_test.dart
@@ -63,8 +63,7 @@ void main() {
             endsWith('>\n'
                 "   Which: printed 'Hello, world!\\n'\n"
                 "                    ''\n"
-                '            which does not contain \'Goodbye\'\n'
-                )
+                '            which does not contain \'Goodbye\'\n')
           ]));
     });
 
@@ -81,8 +80,7 @@ void main() {
                 '  Actual: <'),
             endsWith('>\n'
                 '   Which: printed nothing\n'
-                '            which does not contain \'Goodbye\'\n'
-                )
+                '            which does not contain \'Goodbye\'\n')
           ]));
     });
 

--- a/test/utils_new.dart
+++ b/test/utils_new.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import 'package:test_api/expect.dart';
+import 'package:matcher/expect.dart';
 import 'package:test_api/hooks_testing.dart';
 
 /// Asserts that [monitor] has completed and passed.


### PR DESCRIPTION
These tests were copied from the test repo, and one import was missed.

Fix the test cases for an expanded `contains` mismatch description in #206 
