### PR TITLE
Make the arguments to `expect` dynamic again

### DIFF
--- a/lib/src/expect/expect.dart
+++ b/lib/src/expect/expect.dart
@@ -48,7 +48,7 @@ typedef ErrorFormatter = String Function(Object? actual, Matcher matcher,
 /// the test doesn't complete until the matcher has either matched or failed. If
 /// you want to wait for the matcher to complete before continuing the test, you
 /// can call [expectLater] instead and `await` the result.
-void expect(Object? actual, Object? matcher,
+void expect(dynamic actual, dynamic matcher,
     {String? reason,
     Object? /* String|bool */ skip,
     @Deprecated('Will be removed in 0.13.0.') bool verbose = false,
@@ -68,12 +68,12 @@ void expect(Object? actual, Object? matcher,
 ///
 /// If the matcher fails asynchronously, that failure is piped to the returned
 /// future where it can be handled by user code.
-Future expectLater(Object? actual, Object? matcher,
+Future expectLater(dynamic actual, dynamic matcher,
         {String? reason, Object? /* String|bool */ skip}) =>
     _expect(actual, matcher, reason: reason, skip: skip);
 
 /// The implementation of [expect] and [expectLater].
-Future _expect(actual, matcher,
+Future _expect(Object? actual, Object? matcher,
     {String? reason, skip, bool verbose = false, ErrorFormatter? formatter}) {
   final test = TestHandle.current;
   formatter ??= (actual, matcher, reason, matchState, verbose) {


### PR DESCRIPTION
These were changed to `Object?` from implicit dynamic to satisfy stricter linting in the matcher package, however there are edge cases where changing an argument type from `dynamic` to `Object?` is breaking, so use explicit `dynamic` instead.

The type change can be breaking in cases where it influences inference behavior for one of the arguments. The `dynamic` will not impose a context type on the argument value, while `Object?` does, which changes how generics get inferred.