### PR TITLE
Export more APIs through the expect library

### DIFF
--- a/lib/expect.dart
+++ b/lib/expect.dart
@@ -6,7 +6,7 @@
 
 export 'matcher.dart';
 
-export 'src/expect/expect.dart' show expect, expectLater, fail;
+export 'src/expect/expect.dart' show ErrorFormatter, expect, expectLater, fail;
 export 'src/expect/expect_async.dart'
     show
         Func0,
@@ -48,7 +48,7 @@ export 'src/expect/stream_matchers.dart'
         emitsThrough,
         mayEmitMultiple,
         neverEmits;
-export 'src/expect/throws_matcher.dart' show throwsA;
+export 'src/expect/throws_matcher.dart' show Throws, throws, throwsA;
 export 'src/expect/throws_matchers.dart'
     show
         throwsArgumentError,


### PR DESCRIPTION
When we split `test_api` into smaller libraries I did not include some deprecated or less used APIs through the "focused" library `expect.dart`, while still exporting them through the combined `test_api.dart` library to avoid a backwards incompatibility.

Now that we are moving the APIs to a package we will discontinue, it is not as valuable to try to push migrations between APIs _within_ the package, so re-export them through the `expect.dart` library. This reduces the level of breaking change so that an import update will be all that is needed in every case.