### PR TITLE
Prepare to publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.12.15-dev
+## 0.12.15
 
 * Add `package:matcher/expect.dart` library. Copies the implementation of
   `expect` and the asynchronous matchers from `package:test`.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: matcher
-version: 0.12.14
+version: 0.12.15
 description: >-
   Support for specifying test expectations via an extensible Matcher class.
   Also includes a number of built-in Matcher implementations for common cases.
@@ -19,17 +19,3 @@ dev_dependencies:
   fake_async: ^1.3.0
   lints: ^2.0.0
   test: ^1.23.0
-
-dependency_overrides:
-  test_api:
-    git:
-      url: https://github.com/dart-lang/test
-      path: pkgs/test_api
-  test_core:
-    git:
-      url: https://github.com/dart-lang/test
-      path: pkgs/test_core
-  test:
-    git:
-      url: https://github.com/dart-lang/test
-      path: pkgs/test


### PR DESCRIPTION
This release will introduce a cyclic dependency with `package:test_api`.
The publish will need to happen with a warning from pub.
