### PR TITLE
Expand bound for `test_api` dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.12.16
+
+* Expand bounds on `test_api` dependency to allow the next breaking release
+  which will remove the cyclic dependency on this package.
+
 ## 0.12.15
 
 * Add `package:matcher/expect.dart` library. Copies the implementation of

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: matcher
-version: 0.12.15
+version: 0.12.16
 description: >-
   Support for specifying test expectations via an extensible Matcher class.
   Also includes a number of built-in Matcher implementations for common cases.
@@ -13,7 +13,7 @@ dependencies:
   meta: ^1.8.0
   stack_trace: ^1.10.0
   term_glyph: ^1.2.0
-  test_api: ^0.5.0
+  test_api: ">=0.5.0 <0.7.0"
 
 dev_dependencies:
   fake_async: ^1.3.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,3 +22,4 @@ dev_dependencies:
 
 dependency_overrides:
   test: 1.24.2
+  test_api: 0.5.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,3 +19,6 @@ dev_dependencies:
   fake_async: ^1.3.0
   lints: ^2.0.0
   test: ^1.23.0
+
+dependency_overrides:
+  test: 1.24.2

--- a/test/expect_async_test.dart
+++ b/test/expect_async_test.dart
@@ -336,7 +336,7 @@ void main() {
     test('works with no arguments', () async {
       var callbackRun = false;
       var monitor = await TestCaseMonitor.run(() {
-        // ignore: deprecated_member_use
+        // ignore: deprecated_member_use_from_same_package
         expectAsync(() {
           callbackRun = true;
         })();
@@ -349,7 +349,7 @@ void main() {
     test('works with dynamic arguments', () async {
       var callbackRun = false;
       var monitor = await TestCaseMonitor.run(() {
-        // ignore: deprecated_member_use
+        // ignore: deprecated_member_use_from_same_package
         expectAsync((arg1, arg2) {
           callbackRun = true;
         })(1, 2);
@@ -362,7 +362,7 @@ void main() {
     test('works with non-nullable arguments', () async {
       var callbackRun = false;
       var monitor = await TestCaseMonitor.run(() {
-        // ignore: deprecated_member_use
+        // ignore: deprecated_member_use_from_same_package
         expectAsync((int arg1, int arg2) {
           callbackRun = true;
         })(1, 2);
@@ -375,7 +375,7 @@ void main() {
     test('works with 6 arguments', () async {
       var callbackRun = false;
       var monitor = await TestCaseMonitor.run(() {
-        // ignore: deprecated_member_use
+        // ignore: deprecated_member_use_from_same_package
         expectAsync((arg1, arg2, arg3, arg4, arg5, arg6) {
           callbackRun = true;
         })(1, 2, 3, 4, 5, 6);
@@ -386,7 +386,7 @@ void main() {
     });
 
     test("doesn't support a function with 7 arguments", () {
-      // ignore: deprecated_member_use
+      // ignore: deprecated_member_use_from_same_package
       expect(() => expectAsync((a, b, c, d, e, f, g) {}), throwsArgumentError);
     });
   });

--- a/test/matcher/throws_test.dart
+++ b/test/matcher/throws_test.dart
@@ -15,14 +15,14 @@ void main() {
   group('synchronous', () {
     group('[throws]', () {
       test('with a function that throws an error', () {
-        // ignore: deprecated_member_use
+        // ignore: deprecated_member_use_from_same_package
         expect(() => throw 'oh no', throws);
       });
 
       test("with a function that doesn't throw", () async {
         void local() {}
         var monitor = await TestCaseMonitor.run(() {
-          // ignore: deprecated_member_use
+          // ignore: deprecated_member_use_from_same_package
           expect(local, throws);
         });
 
@@ -38,7 +38,7 @@ void main() {
 
       test('with a non-function', () async {
         var monitor = await TestCaseMonitor.run(() {
-          // ignore: deprecated_member_use
+          // ignore: deprecated_member_use_from_same_package
           expect(10, throws);
         });
 
@@ -114,13 +114,13 @@ void main() {
   group('asynchronous', () {
     group('[throws]', () {
       test('with a Future that throws an error', () {
-        // ignore: deprecated_member_use
+        // ignore: deprecated_member_use_from_same_package
         expect(Future.error('oh no'), throws);
       });
 
       test("with a Future that doesn't throw", () async {
         var monitor = await TestCaseMonitor.run(() {
-          // ignore: deprecated_member_use
+          // ignore: deprecated_member_use_from_same_package
           expect(Future.value(), throws);
         });
 
@@ -135,13 +135,13 @@ void main() {
       });
 
       test('with a closure that returns a Future that throws an error', () {
-        // ignore: deprecated_member_use
+        // ignore: deprecated_member_use_from_same_package
         expect(() => Future.error('oh no'), throws);
       });
 
       test("with a closure that returns a Future that doesn't throw", () async {
         var monitor = await TestCaseMonitor.run(() {
-          // ignore: deprecated_member_use
+          // ignore: deprecated_member_use_from_same_package
           expect(Future.value, throws);
         });
 
@@ -159,7 +159,7 @@ void main() {
         late void Function() callback;
         final monitor = TestCaseMonitor.start(() {
           final completer = Completer<void>();
-          // ignore: deprecated_member_use
+          // ignore: deprecated_member_use_from_same_package
           expect(completer.future, throws);
           callback = () => completer.completeError('oh no');
         });

--- a/test/matcher/throws_type_test.dart
+++ b/test/matcher/throws_type_test.dart
@@ -47,13 +47,13 @@ void main() {
     test('passes when a CyclicInitializationError is thrown', () {
       expect(
           () => _CyclicInitializationFailure().x,
-          // ignore: deprecated_member_use
+          // ignore: deprecated_member_use_from_same_package
           throwsCyclicInitializationError);
     });
 
     test('fails when a non-CyclicInitializationError is thrown', () async {
       var liveTest = await TestCaseMonitor.run(() {
-        // ignore: deprecated_member_use
+        // ignore: deprecated_member_use_from_same_package
         expect(() => throw Exception(), throwsCyclicInitializationError);
       });
 


### PR DESCRIPTION
Allow the next breaking release which will remove the exports of
libraries from this package and remove the cyclic dependency.
