### PR TITLE
Specify language in neverCalled docs for nicer formatting in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.12.17-wip
+
 ## 0.12.16
 
 * Expand bounds on `test_api` dependency to allow the next breaking release

--- a/lib/src/expect/never_called.dart
+++ b/lib/src/expect/never_called.dart
@@ -17,7 +17,7 @@ import 'util/pretty_print.dart';
 /// This can safely be passed in place of any callback that takes ten or fewer
 /// positional parameters. For example:
 ///
-/// ```
+/// ```dart
 /// // Asserts that the stream never emits an event.
 /// stream.listen(neverCalled);
 /// ```

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: matcher
-version: 0.12.16
+version: 0.12.17-wip
 description: >-
   Support for specifying test expectations via an extensible Matcher class.
   Also includes a number of built-in Matcher implementations for common cases.


### PR DESCRIPTION
This will also enable us to enable dartdoc's `missing-code-block-language` warning in Flutter (pkg:matcher is documented together with Flutter).

This also matches the style elsewhere in the repository, e.g. https://github.com/dart-lang/matcher/blob/356e5f68d3484d44b9ef3b814ed95f9de17c7afd/lib/src/custom_matcher.dart#L21