### PR TITLE
Add more advice away from predicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,3 +253,14 @@ why the test failed. For instance compare the failures between
      Which: has length of <2>
 
 ```
+
+### Prefer TypeMatcher to predicate if the match can fail in multiple ways
+
+The `predicate` utility is a convenient shortcut for testing an arbitrary
+(synchronous) property of a value, but it discards context and the failures are
+opaque. If a value could be rejected by the matcher for more than one reason the
+different failure modes cannot be distinguished in the output. Using
+`isA<SomeType>()` and the `TypeMatcher.having` API to extract and test derived
+properties in a structured way brings the context of that structure through to
+failure messages, and failures for differing reasons will have more specific
+output.

--- a/README.md
+++ b/README.md
@@ -257,10 +257,10 @@ why the test failed. For instance compare the failures between
 ### Prefer TypeMatcher to predicate if the match can fail in multiple ways
 
 The `predicate` utility is a convenient shortcut for testing an arbitrary
-(synchronous) property of a value, but it discards context and the failures are
-opaque. If a value could be rejected by the matcher for more than one reason the
-different failure modes cannot be distinguished in the output. Using
-`isA<SomeType>()` and the `TypeMatcher.having` API to extract and test derived
-properties in a structured way brings the context of that structure through to
-failure messages, and failures for differing reasons will have more specific
-output.
+(synchronous) property of a value, but it discards context and failures are
+opaque. Different failure modes cannot be distinguished in the output which is
+determined by a single "description" argument. Using `isA<SomeType>()` and the
+`TypeMatcher.having` API to extract and test derived properties in a structured
+way brings the context of that structure through to failure messages, so
+failures for different reasons will have distinguishable and actionable failure
+messages.

--- a/lib/src/core_matchers.dart
+++ b/lib/src/core_matchers.dart
@@ -306,7 +306,7 @@ class _In<T> extends FeatureMatcher<T> {
 ///
 /// Using an explicit generict argument allows a passed function literal to have
 /// an inferred argument type of [T], and values of the wrong type will be
-/// rejected with an informative meessage.
+/// rejected with an informative message.
 Matcher predicate<T>(bool Function(T) f,
         [String description = 'satisfies function']) =>
     _Predicate(f, description);

--- a/lib/src/core_matchers.dart
+++ b/lib/src/core_matchers.dart
@@ -290,20 +290,29 @@ class _In<T> extends FeatureMatcher<T> {
       description.add('is in ').addDescriptionOf(_source);
 }
 
-/// Returns a matcher that uses an arbitrary function that returns
-/// true or false for the actual value.
+/// Returns a matcher that uses an arbitrary function that returns whether the
+/// value is considered a match.
 ///
 /// For example:
 ///
-///     expect(v, predicate((x) => ((x % 2) == 0), "is even"))
+///     expect(result, predicate<num>((v) => (v % 2) == 0, 'is even'));
+///
+/// Use this method when a value is checked for one conceptual property
+/// described in [description].
+///
+/// If the value can be rejected for than one reason prefer using [isA] and the
+/// [TypeMatcher.having] API to build up a matcher with output that can
+/// distinquish between them.
+///
+/// Using an explicit generict argument allows a passed function literal to have
+/// an inferred argument type of [T], and values of the wrong type will be
+/// rejected with an informative meessage.
 Matcher predicate<T>(bool Function(T) f,
         [String description = 'satisfies function']) =>
     _Predicate(f, description);
 
-typedef _PredicateFunction<T> = bool Function(T value);
-
 class _Predicate<T> extends FeatureMatcher<T> {
-  final _PredicateFunction<T> _matcher;
+  final bool Function(T) _matcher;
   final String _description;
 
   _Predicate(this._matcher, this._description);

--- a/lib/src/core_matchers.dart
+++ b/lib/src/core_matchers.dart
@@ -298,7 +298,7 @@ class _In<T> extends FeatureMatcher<T> {
 ///     expect(actual, predicate<num>((v) => (v % 2) == 0, 'is even'));
 ///
 /// Use this method when a value is checked for one conceptual property
-/// described in [description].
+/// described by [description].
 ///
 /// If the value can be rejected for than one reason prefer using [isA] and the
 /// [TypeMatcher.having] API to build up a matcher with output that can

--- a/lib/src/core_matchers.dart
+++ b/lib/src/core_matchers.dart
@@ -300,8 +300,8 @@ class _In<T> extends FeatureMatcher<T> {
 /// Use this method when a value is checked for one conceptual property
 /// described by [description].
 ///
-/// If the value can be rejected for than one reason prefer using [isA] and the
-/// [TypeMatcher.having] API to build up a matcher with output that can
+/// If the value can be rejected for more than one reason prefer using [isA] and
+/// the [TypeMatcher.having] API to build up a matcher with output that can
 /// distinquish between them.
 ///
 /// Using an explicit generict argument allows a passed function literal to have

--- a/lib/src/core_matchers.dart
+++ b/lib/src/core_matchers.dart
@@ -295,7 +295,7 @@ class _In<T> extends FeatureMatcher<T> {
 ///
 /// For example:
 ///
-///     expect(result, predicate<num>((v) => (v % 2) == 0, 'is even'));
+///     expect(actual, predicate<num>((v) => (v % 2) == 0, 'is even'));
 ///
 /// Use this method when a value is checked for one conceptual property
 /// described in [description].


### PR DESCRIPTION
Add a best practice entry and expand the dartdoc for `predicate` to
mention that the failure messages are not as detailed as `TypeMatcher`,
and that the latter is preferred when the value can fail in more than
one way.

Add a generic argument to the example usage - most cases should prefer
to include a generic.

Cleanup an unnecessary private `typedef` with a single usage.
