### PR TITLE
Updated lints package, fixed static analysis issue

### DIFF
--- a/lib/matcher.dart
+++ b/lib/matcher.dart
@@ -3,6 +3,8 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Support for specifying test expectations, such as for unit tests.
+library matcher;
+
 export 'src/core_matchers.dart';
 export 'src/custom_matcher.dart';
 export 'src/description.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
 
 dev_dependencies:
   fake_async: ^1.3.0
-  lints: ^2.0.0
+  lints: ^3.0.0
   test: ^1.23.0
 
 dependency_overrides:


### PR DESCRIPTION
1.Updated lints package from 2.0.0 to 3.0.0.
2. Fixed static analysis issue reported by pub.dev:
![obraz](https://github.com/dart-lang/matcher/assets/32015883/8457ad47-67ad-4ff5-b301-d65002674e45)

Docs:
https://dart.dev/tools/linter-rules/dangling_library_doc_comments